### PR TITLE
feat: init mechain

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,6 +10,8 @@ TOPRF_SHARE_PRIVATE_KEY=
 TOPRF_SHARE_PUBLIC_KEY=
 # Overall public key for the threshold signature
 TOPRF_PUBLIC_KEY=
+# Private key for a $MOCA-holding account
+MECHAIN_PRIVATE_KEY=
 # Provide a https proxy URL to allow for the creation of geo-specified
 # tunnels. The attestor will replace {{geolocation}} in the URL
 # with the geolocation it needs to connect to. geolocation is a 2-letter

--- a/src/mechain/abis/governanceABI.ts
+++ b/src/mechain/abis/governanceABI.ts
@@ -1,0 +1,458 @@
+export const governanceABI = [
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'initialOwner',
+				'type': 'address'
+			},
+			{
+				'internalType': 'uint256',
+				'name': '_minimumStake',
+				'type': 'uint256'
+			},
+			{
+				'internalType': 'uint256',
+				'name': '_unbondingPeriod',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'nonpayable',
+		'type': 'constructor'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'owner',
+				'type': 'address'
+			}
+		],
+		'name': 'OwnableInvalidOwner',
+		'type': 'error'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'account',
+				'type': 'address'
+			}
+		],
+		'name': 'OwnableUnauthorizedAccount',
+		'type': 'error'
+	},
+	{
+		'anonymous': false,
+		'inputs': [
+			{
+				'indexed': true,
+				'internalType': 'address',
+				'name': 'previousOwner',
+				'type': 'address'
+			},
+			{
+				'indexed': true,
+				'internalType': 'address',
+				'name': 'newOwner',
+				'type': 'address'
+			}
+		],
+		'name': 'OwnershipTransferred',
+		'type': 'event'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'string',
+				'name': '',
+				'type': 'string'
+			}
+		],
+		'name': 'Attestors',
+		'outputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'string',
+				'name': '_key',
+				'type': 'string'
+			},
+			{
+				'internalType': 'address',
+				'name': '_address',
+				'type': 'address'
+			}
+		],
+		'name': 'addAttestor',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'claimRewards',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'string',
+				'name': '_key',
+				'type': 'string'
+			}
+		],
+		'name': 'getAttestor',
+		'outputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'getAttestors',
+		'outputs': [
+			{
+				'internalType': 'string[]',
+				'name': 'keys',
+				'type': 'string[]'
+			},
+			{
+				'internalType': 'address[]',
+				'name': 'addresses',
+				'type': 'address[]'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'minimumStake',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'owner',
+		'outputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'name': 'pendingRewards',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'reclaimContractAddress',
+		'outputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address[]',
+				'name': '_attestorAddresses',
+				'type': 'address[]'
+			}
+		],
+		'name': 'registerRewards',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'string',
+				'name': '_key',
+				'type': 'string'
+			}
+		],
+		'name': 'removeAttestor',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'renounceOwnership',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'requestUnstake',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint256',
+				'name': '_minimumStake',
+				'type': 'uint256'
+			}
+		],
+		'name': 'setMinimumStake',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': '_reclaimContractAddress',
+				'type': 'address'
+			}
+		],
+		'name': 'setReclaimContractAddress',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'bool',
+				'name': '_slashingEnabled',
+				'type': 'bool'
+			}
+		],
+		'name': 'setSlashingEnabled',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint256',
+				'name': '_unbondingPeriod',
+				'type': 'uint256'
+			}
+		],
+		'name': 'setUnbondingPeriod',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint256',
+				'name': '_verificationCost',
+				'type': 'uint256'
+			}
+		],
+		'name': 'setVerificationCost',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint256',
+				'name': '_amount',
+				'type': 'uint256'
+			}
+		],
+		'name': 'slash',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'slashingEnabled',
+		'outputs': [
+			{
+				'internalType': 'bool',
+				'name': '',
+				'type': 'bool'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'stake',
+		'outputs': [],
+		'stateMutability': 'payable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'name': 'stakedAmounts',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'totalSlashedAmount',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'totalStaked',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'newOwner',
+				'type': 'address'
+			}
+		],
+		'name': 'transferOwnership',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'unbondingPeriod',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'unstake',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'name': 'unstakeRequestBlocks',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'verificationCost',
+		'outputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'withdraw',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	}
+]

--- a/src/mechain/abis/taskABI.ts
+++ b/src/mechain/abis/taskABI.ts
@@ -1,0 +1,509 @@
+export const taskABI = [
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'initialOwner',
+				'type': 'address'
+			},
+			{
+				'internalType': 'address',
+				'name': '_governanceAddress',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'nonpayable',
+		'type': 'constructor'
+	},
+	{
+		'inputs': [],
+		'name': 'ECDSAInvalidSignature',
+		'type': 'error'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint256',
+				'name': 'length',
+				'type': 'uint256'
+			}
+		],
+		'name': 'ECDSAInvalidSignatureLength',
+		'type': 'error'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'bytes32',
+				'name': 's',
+				'type': 'bytes32'
+			}
+		],
+		'name': 'ECDSAInvalidSignatureS',
+		'type': 'error'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'owner',
+				'type': 'address'
+			}
+		],
+		'name': 'OwnableInvalidOwner',
+		'type': 'error'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'account',
+				'type': 'address'
+			}
+		],
+		'name': 'OwnableUnauthorizedAccount',
+		'type': 'error'
+	},
+	{
+		'anonymous': false,
+		'inputs': [
+			{
+				'indexed': true,
+				'internalType': 'address',
+				'name': 'previousOwner',
+				'type': 'address'
+			},
+			{
+				'indexed': true,
+				'internalType': 'address',
+				'name': 'newOwner',
+				'type': 'address'
+			}
+		],
+		'name': 'OwnershipTransferred',
+		'type': 'event'
+	},
+	{
+		'anonymous': false,
+		'inputs': [
+			{
+				'components': [
+					{
+						'internalType': 'uint32',
+						'name': 'id',
+						'type': 'uint32'
+					},
+					{
+						'internalType': 'uint32',
+						'name': 'timestampStart',
+						'type': 'uint32'
+					},
+					{
+						'internalType': 'uint32',
+						'name': 'timestampEnd',
+						'type': 'uint32'
+					},
+					{
+						'components': [
+							{
+								'internalType': 'address',
+								'name': 'addr',
+								'type': 'address'
+							},
+							{
+								'internalType': 'string',
+								'name': 'host',
+								'type': 'string'
+							}
+						],
+						'internalType': 'struct ReclaimTask.Attestor[]',
+						'name': 'attestors',
+						'type': 'tuple[]'
+					}
+				],
+				'indexed': false,
+				'internalType': 'struct ReclaimTask.Task',
+				'name': 'task',
+				'type': 'tuple'
+			}
+		],
+		'name': 'TaskAdded',
+		'type': 'event'
+	},
+	{
+		'inputs': [],
+		'name': 'ZERO_ADDRESS',
+		'outputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint32',
+				'name': '',
+				'type': 'uint32'
+			}
+		],
+		'name': 'consensusReached',
+		'outputs': [
+			{
+				'internalType': 'bool',
+				'name': '',
+				'type': 'bool'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'bytes32',
+				'name': 'seed',
+				'type': 'bytes32'
+			},
+			{
+				'internalType': 'uint32',
+				'name': 'timestamp',
+				'type': 'uint32'
+			}
+		],
+		'name': 'createNewTaskRequest',
+		'outputs': [
+			{
+				'internalType': 'uint32',
+				'name': '',
+				'type': 'uint32'
+			},
+			{
+				'components': [
+					{
+						'internalType': 'address',
+						'name': 'addr',
+						'type': 'address'
+					},
+					{
+						'internalType': 'string',
+						'name': 'host',
+						'type': 'string'
+					}
+				],
+				'internalType': 'struct ReclaimTask.Attestor[]',
+				'name': '',
+				'type': 'tuple[]'
+			}
+		],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'currentTask',
+		'outputs': [
+			{
+				'internalType': 'uint32',
+				'name': '',
+				'type': 'uint32'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'bytes32',
+				'name': 'seed',
+				'type': 'bytes32'
+			},
+			{
+				'internalType': 'uint32',
+				'name': 'timestamp',
+				'type': 'uint32'
+			}
+		],
+		'name': 'fetchAttestorsForClaim',
+		'outputs': [
+			{
+				'components': [
+					{
+						'internalType': 'address',
+						'name': 'addr',
+						'type': 'address'
+					},
+					{
+						'internalType': 'string',
+						'name': 'host',
+						'type': 'string'
+					}
+				],
+				'internalType': 'struct ReclaimTask.Attestor[]',
+				'name': '',
+				'type': 'tuple[]'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint32',
+				'name': 'task',
+				'type': 'uint32'
+			}
+		],
+		'name': 'fetchTask',
+		'outputs': [
+			{
+				'components': [
+					{
+						'internalType': 'uint32',
+						'name': 'id',
+						'type': 'uint32'
+					},
+					{
+						'internalType': 'uint32',
+						'name': 'timestampStart',
+						'type': 'uint32'
+					},
+					{
+						'internalType': 'uint32',
+						'name': 'timestampEnd',
+						'type': 'uint32'
+					},
+					{
+						'components': [
+							{
+								'internalType': 'address',
+								'name': 'addr',
+								'type': 'address'
+							},
+							{
+								'internalType': 'string',
+								'name': 'host',
+								'type': 'string'
+							}
+						],
+						'internalType': 'struct ReclaimTask.Attestor[]',
+						'name': 'attestors',
+						'type': 'tuple[]'
+					}
+				],
+				'internalType': 'struct ReclaimTask.Task',
+				'name': '',
+				'type': 'tuple'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'governanceAddress',
+		'outputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'owner',
+		'outputs': [
+			{
+				'internalType': 'address',
+				'name': '',
+				'type': 'address'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'renounceOwnership',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'requiredAttestors',
+		'outputs': [
+			{
+				'internalType': 'uint8',
+				'name': '',
+				'type': 'uint8'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint8',
+				'name': '_requiredAttestors',
+				'type': 'uint8'
+			}
+		],
+		'name': 'setRequiredAttestors',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [],
+		'name': 'taskDurationS',
+		'outputs': [
+			{
+				'internalType': 'uint32',
+				'name': '',
+				'type': 'uint32'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'uint256',
+				'name': '',
+				'type': 'uint256'
+			}
+		],
+		'name': 'tasks',
+		'outputs': [
+			{
+				'internalType': 'uint32',
+				'name': 'id',
+				'type': 'uint32'
+			},
+			{
+				'internalType': 'uint32',
+				'name': 'timestampStart',
+				'type': 'uint32'
+			},
+			{
+				'internalType': 'uint32',
+				'name': 'timestampEnd',
+				'type': 'uint32'
+			}
+		],
+		'stateMutability': 'view',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'internalType': 'address',
+				'name': 'newOwner',
+				'type': 'address'
+			}
+		],
+		'name': 'transferOwnership',
+		'outputs': [],
+		'stateMutability': 'nonpayable',
+		'type': 'function'
+	},
+	{
+		'inputs': [
+			{
+				'components': [
+					{
+						'components': [
+							{
+								'internalType': 'string',
+								'name': 'provider',
+								'type': 'string'
+							},
+							{
+								'internalType': 'string',
+								'name': 'parameters',
+								'type': 'string'
+							},
+							{
+								'internalType': 'string',
+								'name': 'context',
+								'type': 'string'
+							}
+						],
+						'internalType': 'struct Claims.ClaimInfo',
+						'name': 'claimInfo',
+						'type': 'tuple'
+					},
+					{
+						'components': [
+							{
+								'components': [
+									{
+										'internalType': 'bytes32',
+										'name': 'identifier',
+										'type': 'bytes32'
+									},
+									{
+										'internalType': 'address',
+										'name': 'owner',
+										'type': 'address'
+									},
+									{
+										'internalType': 'uint32',
+										'name': 'timestampS',
+										'type': 'uint32'
+									},
+									{
+										'internalType': 'uint32',
+										'name': 'epoch',
+										'type': 'uint32'
+									}
+								],
+								'internalType': 'struct Claims.CompleteClaimData',
+								'name': 'claim',
+								'type': 'tuple'
+							},
+							{
+								'internalType': 'bytes[]',
+								'name': 'signatures',
+								'type': 'bytes[]'
+							}
+						],
+						'internalType': 'struct Claims.SignedClaim',
+						'name': 'signedClaim',
+						'type': 'tuple'
+					}
+				],
+				'internalType': 'struct ReclaimTask.Proof[]',
+				'name': 'proofs',
+				'type': 'tuple[]'
+			},
+			{
+				'internalType': 'uint32',
+				'name': 'taskId',
+				'type': 'uint32'
+			}
+		],
+		'name': 'verifyProofs',
+		'outputs': [
+			{
+				'internalType': 'bool',
+				'name': '',
+				'type': 'bool'
+			}
+		],
+		'stateMutability': 'payable',
+		'type': 'function'
+	}
+]

--- a/src/mechain/client/create-claim-on-mechain.ts
+++ b/src/mechain/client/create-claim-on-mechain.ts
@@ -64,7 +64,7 @@ export async function createClaimOnMechain<N extends ProviderName>({
 }
 
 async function getContracts() {
-	const privateKey: string = process.env.PRIVATE_KEY!
+	const privateKey: string = process.env.MECHAIN_PRIVATE_KEY!
 
 	const provider = new providers.JsonRpcProvider(RPC_URL)
 	const signer = new Wallet(privateKey, provider)

--- a/src/mechain/client/create-claim-on-mechain.ts
+++ b/src/mechain/client/create-claim-on-mechain.ts
@@ -1,0 +1,82 @@
+
+import { Contract, providers, utils, Wallet } from 'ethers'
+import { createClaimOnAttestor as _createClaimOnAttestor } from 'src/client'
+import { AttestorClient } from 'src/client'
+import { governanceABI } from 'src/mechain/abis/governanceABI'
+import { taskABI } from 'src/mechain/abis/taskABI'
+import { GOVERNANCE_CONTRACT_ADDRESS, RPC_URL, TASK_CONTRACT_ADDRESS } from 'src/mechain/constants'
+import { CreateClaimOnMechainOpts } from 'src/mechain/types'
+import { ClaimTunnelResponse } from 'src/proto/api'
+import { ProviderName } from 'src/types'
+
+/**
+ * Creates a Reclaim claim on the AVS chain.
+ */
+export async function createClaimOnMechain<N extends ProviderName>({
+	createClaimOnAttestor = _createClaimOnAttestor,
+	...opts
+}: CreateClaimOnMechainOpts<N>) {
+
+	const { taskContract } = await getContracts()
+
+	// Construct parameters for the createNewTaskRequest function
+	const seed = utils.randomBytes(32)
+	const timestamp = Math.floor(Date.now() / 1000)
+
+	// Perform a static call to fetch taskId and attestors for the next task
+	const result = await taskContract.callStatic.createNewTaskRequest(
+		seed,
+		timestamp
+	)
+	const taskId = result[0]
+
+	// fetch requiredAttestors to determine how many proofs to request
+	const requiredAttestors = await taskContract.requiredAttestors()
+
+	const responses: ClaimTunnelResponse [] = []
+
+	for(let i = 0; i < requiredAttestors; i++) {
+		// Fetched attestors's WebSocket URI, e.g. wss://attestor.reclaimprotocol.org/ws
+		const host = result[1][i].host
+
+		const client = new AttestorClient({
+			url: host
+		})
+
+		const res = await createClaimOnAttestor ({
+			...opts,
+			client
+		})
+
+		responses.push(res)
+	}
+
+	// Perform the call that was statically-called previously
+	const tx = await taskContract.createNewTaskRequest(seed, timestamp)
+	await tx.wait()
+
+	return { taskId, responses }
+
+}
+
+async function getContracts() {
+	const privateKey: string = process.env.PRIVATE_KEY!
+
+	const provider = new providers.JsonRpcProvider(RPC_URL)
+	const signer = new Wallet(privateKey, provider)
+
+	const taskContract = new Contract(
+		TASK_CONTRACT_ADDRESS,
+		taskABI,
+		signer
+	)
+
+	const governanceContract = new Contract(
+		GOVERNANCE_CONTRACT_ADDRESS,
+		governanceABI,
+		signer
+	)
+
+	return { taskContract, governanceContract }
+}
+

--- a/src/mechain/client/create-claim-on-mechain.ts
+++ b/src/mechain/client/create-claim-on-mechain.ts
@@ -6,8 +6,9 @@ import { governanceABI } from 'src/mechain/abis/governanceABI'
 import { taskABI } from 'src/mechain/abis/taskABI'
 import { GOVERNANCE_CONTRACT_ADDRESS, RPC_URL, TASK_CONTRACT_ADDRESS } from 'src/mechain/constants'
 import { CreateClaimOnMechainOpts } from 'src/mechain/types'
-import { ClaimTunnelResponse } from 'src/proto/api'
 import { ProviderName } from 'src/types'
+import { CreateClaimResponse } from 'src/window-rpc'
+import { mapToCreateClaimResponse } from 'src/window-rpc/utils'
 
 /**
  * Creates a Reclaim claim on the AVS chain.
@@ -33,7 +34,7 @@ export async function createClaimOnMechain<N extends ProviderName>({
 	// fetch requiredAttestors to determine how many proofs to request
 	const requiredAttestors = await taskContract.requiredAttestors()
 
-	const responses: ClaimTunnelResponse [] = []
+	const responses: CreateClaimResponse [] = []
 
 	for(let i = 0; i < requiredAttestors; i++) {
 		// Fetched attestors's WebSocket URI, e.g. wss://attestor.reclaimprotocol.org/ws
@@ -43,12 +44,15 @@ export async function createClaimOnMechain<N extends ProviderName>({
 			url: host
 		})
 
-		const res = await createClaimOnAttestor ({
+		const claimTunnelRes = await createClaimOnAttestor ({
 			...opts,
 			client
 		})
 
-		responses.push(res)
+		const response = mapToCreateClaimResponse(
+			claimTunnelRes
+		)
+		responses.push(response)
 	}
 
 	// Perform the call that was statically-called previously

--- a/src/mechain/client/create-claim-on-mechain.ts
+++ b/src/mechain/client/create-claim-on-mechain.ts
@@ -73,7 +73,7 @@ export async function createClaimOnMechain<N extends ProviderName>({
 async function getContracts() {
 	const privateKey = process.env.MECHAIN_PRIVATE_KEY!
 	if(!privateKey) {
-		throw new Error('PRIVATE_KEY environment variable is not set')
+		throw new Error('MECHAIN_PRIVATE_KEY environment variable is not set')
 	}
 
 	try {

--- a/src/mechain/constants/index.ts
+++ b/src/mechain/constants/index.ts
@@ -2,4 +2,4 @@ export const TASK_CONTRACT_ADDRESS = '0x88cEd91D4966D82912774B9fdf9ca4E065881a91
 
 export const GOVERNANCE_CONTRACT_ADDRESS = '0x0E2CF8810B11c2875246d634f030897e77491680'
 
-export const RPC_URL = 'https://testnet-rpc.mechain.tech '
+export const RPC_URL = 'https://testnet-rpc.mechain.tech'

--- a/src/mechain/constants/index.ts
+++ b/src/mechain/constants/index.ts
@@ -1,0 +1,5 @@
+export const TASK_CONTRACT_ADDRESS = '0x88cEd91D4966D82912774B9fdf9ca4E065881a91'
+
+export const GOVERNANCE_CONTRACT_ADDRESS = '0x0E2CF8810B11c2875246d634f030897e77491680'
+
+export const RPC_URL = 'https://testnet-rpc.mechain.tech '

--- a/src/mechain/types/index.ts
+++ b/src/mechain/types/index.ts
@@ -1,0 +1,12 @@
+import type { createClaimOnAttestor } from 'src/client'
+import type { CreateClaimOnAttestorOpts, ProviderName } from 'src/types'
+
+
+export type CreateClaimOnMechainOpts<N extends ProviderName> = (
+    Omit<CreateClaimOnAttestorOpts<N>, 'onStep' | 'client'>
+) & {
+    /**
+     * Override the default createClaimOnAttestor function
+     */
+    createClaimOnAttestor?: typeof createClaimOnAttestor
+}

--- a/src/mechain/types/index.ts
+++ b/src/mechain/types/index.ts
@@ -1,10 +1,22 @@
 import type { createClaimOnAttestor } from 'src/client'
 import type { CreateClaimOnAttestorOpts, ProviderName } from 'src/types'
 
+export type CreateClaimOnMechainStep = {
+    type: 'taskCreated'
+    data: number
+}| {
+    type: 'requiredAttestorsFetched'
+    data: number
+} | {
+    type: 'attestorFetched'
+    data: string
+}
+
 
 export type CreateClaimOnMechainOpts<N extends ProviderName> = (
     Omit<CreateClaimOnAttestorOpts<N>, 'onStep' | 'client'>
 ) & {
+    onStep?(step: CreateClaimOnMechainStep): void
     /**
      * Override the default createClaimOnAttestor function
      */

--- a/src/window-rpc/setup-window-rpc.ts
+++ b/src/window-rpc/setup-window-rpc.ts
@@ -166,6 +166,14 @@ export function setupWindowRpc() {
 						req.request.zkOperatorMode, req.request.zkEngine
 					),
 					logger,
+					onStep(step) {
+						sendMessage({
+							type: 'createClaimOnMechainStep',
+							step,
+							module: req.module,
+							id: req.id,
+						})
+					},
 				})
 				respond({
 					type: 'createClaimOnMechainDone',
@@ -181,6 +189,7 @@ export function setupWindowRpc() {
 						req.request.contentsOnly
 					),
 				})
+
 				break
 			case 'extractJSONValueIndex':
 				respond({

--- a/src/window-rpc/setup-window-rpc.ts
+++ b/src/window-rpc/setup-window-rpc.ts
@@ -2,6 +2,7 @@ import { uint8ArrayToStr } from '@reclaimprotocol/tls'
 import { ZKEngine } from '@reclaimprotocol/zk-symmetric-crypto'
 import { createClaimOnAvs } from 'src/avs/client/create-claim-on-avs'
 import { createClaimOnAttestor } from 'src/client'
+import { createClaimOnMechain } from 'src/mechain/client/create-claim-on-mechain'
 import { extractHTMLElement, extractJSONValueIndex, generateRequstAndResponseFromTranscript } from 'src/providers/http/utils'
 import { OPRFOperators, ProviderParams, ProviderSecretParams, ZKOperators } from 'src/types'
 import { logger as LOGGER, makeLogger } from 'src/utils'
@@ -150,6 +151,25 @@ export function setupWindowRpc() {
 				respond({
 					type: 'createClaimOnAvsDone',
 					response: avsRes,
+				})
+				break
+			case 'createClaimOnMechain':
+				const mechainRes = await createClaimOnMechain({
+					...req.request,
+					context: req.request.context
+						? JSON.parse(req.request.context)
+						: undefined,
+					zkOperators: getZkOperators(
+						req.request.zkOperatorMode, req.request.zkEngine
+					),
+					oprfOperators: getOprfOperators(
+						req.request.zkOperatorMode, req.request.zkEngine
+					),
+					logger,
+				})
+				respond({
+					type: 'createClaimOnMechainDone',
+					response: mechainRes,
 				})
 				break
 			case 'extractHtmlElement':

--- a/src/window-rpc/types.ts
+++ b/src/window-rpc/types.ts
@@ -1,6 +1,7 @@
 import type { OPRFOperator, ZKEngine, ZKOperator } from '@reclaimprotocol/zk-symmetric-crypto'
 import type { TaskCompletedEventObject } from 'src/avs/contracts/ReclaimServiceManager'
 import type { CreateClaimOnAvsOpts, CreateClaimOnAvsStep } from 'src/avs/types'
+import type { CreateClaimOnMechainStep } from 'src/mechain/types'
 import { AuthenticationRequest } from 'src/proto/api'
 import type { extractHTMLElement, extractJSONValueIndex } from 'src/providers/http/utils'
 import type {
@@ -236,6 +237,12 @@ export type WindowRPCOutgoingMsg = (
 		{
 			type: 'createClaimOnAvsStep'
 			step: CreateClaimOnAvsStep
+		}
+	)
+	| (
+		{
+			type: 'createClaimOnMechainStep'
+			step: CreateClaimOnMechainStep
 		}
 	)
 	| (

--- a/src/window-rpc/types.ts
+++ b/src/window-rpc/types.ts
@@ -53,6 +53,11 @@ export type RPCCreateClaimOnAvsOptions<N extends ProviderName = any> = Omit<
 	payer?: 'attestor'
 } & CreateClaimRPCBaseOpts
 
+export type RPCCreateClaimOnMechainOptions<N extends ProviderName = any> = Omit<
+	CreateClaimOnAvsOpts<N>,
+	'zkOperators' | 'context'
+> & CreateClaimRPCBaseOpts
+
 type ExtractHTMLElementOptions = {
 	html: string
 	xpathExpression: string
@@ -83,6 +88,10 @@ type AVSCreateResult = {
 	txHash: string
 }
 
+type MechainCreateResult = {
+	taskId: number
+}
+
 /**
  * Legacy V1 create claim response
  */
@@ -109,6 +118,10 @@ export type WindowRPCClient = {
 	 * Create a claim on the AVS
 	 */
 	createClaimOnAvs(opts: RPCCreateClaimOnAvsOptions): Promise<AVSCreateResult>
+	/**
+	 * Create a claim on Mechain
+	 */
+	createClaimOnMechain(opts: RPCCreateClaimOnMechainOptions): Promise<MechainCreateResult>
 	/**
 	 * Extract an HTML element from a string of HTML
 	 */
@@ -183,6 +196,7 @@ type AsResponse<T> = T & { isResponse: true }
 export type WindowRPCIncomingMsg = (
 	WindowRPCRequest<WindowRPCClient, 'createClaim'>
 	| WindowRPCRequest<WindowRPCClient, 'createClaimOnAvs'>
+	| WindowRPCRequest<WindowRPCClient, 'createClaimOnMechain'>
 	| WindowRPCRequest<WindowRPCClient, 'extractHtmlElement'>
 	| WindowRPCRequest<WindowRPCClient, 'extractJSONValueIndex'>
 	| WindowRPCRequest<WindowRPCClient, 'getCurrentMemoryUsage'>


### PR DESCRIPTION
This PR introduces a chain-based decentralization setup feature for attestors. Following the schema implemented, there will be an option to request multiple proofs from multiple attestors randomly selected from a smart contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enhanced smart contract interfaces for governance and task management.
  - Introduced an automated claim initiation process that streamlines task creation and attestor response collection.
  - Expanded RPC integration to support seamless claim request handling.
  - Included new configuration settings for network endpoints and contract addresses.
  - Provided flexible type definitions for customizable claim processing.
  - Added a new environment variable for private key configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->