### PR TITLE
docs: fix typo in "threshholded" to "thresholded"

### DIFF
--- a/docs/claim-creation.md
+++ b/docs/claim-creation.md
@@ -199,7 +199,7 @@ There you have it! The complete flow for creating a claim on a attestor.
 
 ## TOPRF
 
-We support threshholded [OPRF](https://en.wikipedia.org/wiki/Oblivious_pseudorandom_function) to obscure sensitive data in a proof in a consistent way.
+We support thresholded [OPRF](https://en.wikipedia.org/wiki/Oblivious_pseudorandom_function) to obscure sensitive data in a proof in a consistent way.
 
 Let's take an example of where this may be used. Say you want your users to prove their DOB to you via some govt. ID, and simultaneously want to ensure no two users submit the same ID proof to you. To de-duplicate the data, you'll need to see their ID number, which they may not want to reveal to you.
 
@@ -209,7 +209,7 @@ This is where TOPRF comes in -- it allows you to verify the uniqueness of the ID
 
 A simple hash such as SHA256 could work, though in certain cases, it may not be secure as hackers or malicious actors can use a rainbow table to reverse the hash.
 
-OPRF gets around that by requiring a server (the attestor) to generate the hash, rate-limiting any attempts to build a rainbow table. Moreover, with TOPRF (threshholded OPRF), no single server can generate the hash -- it requires multiple servers to come together to generate the hash, further securing the data.
+OPRF gets around that by requiring a server (the attestor) to generate the hash, rate-limiting any attempts to build a rainbow table. Moreover, with TOPRF (thresholded OPRF), no single server can generate the hash -- it requires multiple servers to come together to generate the hash, further securing the data.
 
 ### Can the attestor see the private data I am hashing? 
 


### PR DESCRIPTION
### Description

a typo in the documentation where the word "threshholded" was used instead of the correct "thresholded." This appeared in the **TOPRF** section:

- "We support threshholded [[OPRF](https://en.wikipedia.org/wiki/Oblivious_pseudorandom_function)](https://en.wikipedia.org/wiki/Oblivious_pseudorandom_function) to obscure sensitive data..."
- "Moreover, with TOPRF (threshholded OPRF), no single server can generate the hash..."

Both instances have been updated to "**thresholded**" for accuracy.
### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error to improve terminology clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->