### PR TITLE
Change rpc response type

### DIFF
--- a/src/mechain/client/create-claim-on-mechain.ts
+++ b/src/mechain/client/create-claim-on-mechain.ts
@@ -1,9 +1,8 @@
 import { createClaimOnAttestor as _createClaimOnAttestor, getAttestorClientFromPool } from 'src/client'
 import { AttestorClient } from 'src/client'
 import { CreateClaimOnMechainOpts } from 'src/mechain/types'
+import { ClaimTunnelResponse } from 'src/proto/api'
 import { ProviderName } from 'src/types'
-import { CreateClaimResponse } from 'src/window-rpc'
-import { mapToCreateClaimResponse } from 'src/window-rpc/utils'
 
 /**
  * Creates a Reclaim claim on the AVS chain.
@@ -26,7 +25,7 @@ export async function createClaimOnMechain<N extends ProviderName>({
 		timestamp: timestamp
 	})
 
-	const responses: CreateClaimResponse [] = []
+	const responses: ClaimTunnelResponse [] = []
 
 	for(let i = 0; i < requiredAttestors; i++) {
 
@@ -41,12 +40,8 @@ export async function createClaimOnMechain<N extends ProviderName>({
 			client
 		})
 
-		const response = mapToCreateClaimResponse(
-			claimTunnelRes
-		)
-		responses.push(response)
+		responses.push(claimTunnelRes)
 	}
-
 
 	onStep?.({ type: 'taskCreated', data: taskId })
 

--- a/src/window-rpc/setup-window-rpc.ts
+++ b/src/window-rpc/setup-window-rpc.ts
@@ -185,7 +185,7 @@ export function setupWindowRpc() {
 
 				respond({
 					type: 'createClaimOnMechainDone',
-					response: { taskId: mechainRes.taskId, response: claimResponses },
+					response: { taskId: mechainRes.taskId, data: claimResponses },
 				})
 				break
 			case 'extractHtmlElement':

--- a/src/window-rpc/setup-window-rpc.ts
+++ b/src/window-rpc/setup-window-rpc.ts
@@ -8,7 +8,7 @@ import { OPRFOperators, ProviderParams, ProviderSecretParams, ZKOperators } from
 import { logger as LOGGER, makeLogger } from 'src/utils'
 import { B64_JSON_REPLACER, B64_JSON_REVIVER } from 'src/utils/b64-json'
 import { Benchmark } from 'src/utils/benchmark'
-import { CommunicationBridge, RPCCreateClaimOptions, WindowRPCClient, WindowRPCErrorResponse, WindowRPCIncomingMsg, WindowRPCOutgoingMsg, WindowRPCResponse } from 'src/window-rpc/types'
+import { CommunicationBridge, CreateClaimResponse, RPCCreateClaimOptions, WindowRPCClient, WindowRPCErrorResponse, WindowRPCIncomingMsg, WindowRPCOutgoingMsg, WindowRPCResponse } from 'src/window-rpc/types'
 import { generateRpcRequestId, getCurrentMemoryUsage, getWsApiUrlFromLocation, mapToCreateClaimResponse, waitForResponse } from 'src/window-rpc/utils'
 import { ALL_ENC_ALGORITHMS, makeWindowRpcOprfOperator, makeWindowRpcZkOperator } from 'src/window-rpc/window-rpc-zk'
 
@@ -178,9 +178,14 @@ export function setupWindowRpc() {
 						})
 					},
 				})
+				const claimResponses: CreateClaimResponse[] = []
+				for(let i = 0; i < mechainRes.responses.length; i++) {
+					claimResponses[i] = mapToCreateClaimResponse(mechainRes.responses[i])
+				}
+
 				respond({
 					type: 'createClaimOnMechainDone',
-					response: mechainRes,
+					response: { taskId: mechainRes.taskId, response: claimResponses },
 				})
 				break
 			case 'extractHtmlElement':

--- a/src/window-rpc/types.ts
+++ b/src/window-rpc/types.ts
@@ -91,7 +91,7 @@ type AVSCreateResult = {
 
 type MechainCreateResult = {
 	taskId: number
-	response: CreateClaimResponse[]
+	data: CreateClaimResponse[]
 }
 
 /**

--- a/src/window-rpc/types.ts
+++ b/src/window-rpc/types.ts
@@ -91,6 +91,7 @@ type AVSCreateResult = {
 
 type MechainCreateResult = {
 	taskId: number
+	response: CreateClaimResponse[]
 }
 
 /**


### PR DESCRIPTION
Destructured createClaimOnMechain response to map to CreateClaimResponse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claim creation now returns a structured, detailed response including a unique task identifier and comprehensive claim details.
  
- **Refactor**
  - Streamlined the processing of claim responses for a more direct and efficient workflow.
  - Enhanced the `MechainCreateResult` type to include an array of claim response objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->