### PR TITLE
Module iife

### DIFF
--- a/src/external-rpc/handle-incoming-msg.ts
+++ b/src/external-rpc/handle-incoming-msg.ts
@@ -103,7 +103,7 @@ async function _handleIncomingMessage(req: ExternalRPCIncomingMsg): Promise<
 						name: 'attestor-progress',
 						step,
 					},
-					id: generateRpcRequestId(),
+					id: req.id,
 				})
 			},
 			updateProviderParams : req.request.updateProviderParams

--- a/src/external-rpc/setup-jsc.ts
+++ b/src/external-rpc/setup-jsc.ts
@@ -5,6 +5,7 @@ import { setCryptoImplementation } from '@reclaimprotocol/tls'
 import { pureJsCrypto } from '@reclaimprotocol/tls/purejs-crypto'
 
 import { makeLogger } from '#src/utils/logger.ts'
+import { handleIncomingMessage } from '#src/external-rpc/index.ts'
 
 declare global {
 	/**
@@ -33,5 +34,8 @@ export function setupFlutterJsRpc(baseUrl: string, channel = 'attestor-core') {
 
 	globalThis[channel] = rpcChannel
 }
+
+globalThis.setupFlutterJsRpc = setupFlutterJsRpc;
+globalThis.handleIncomingMessage = handleIncomingMessage;
 
 export * from '#src/external-rpc/index.ts'

--- a/src/scripts/build-jsc.ts
+++ b/src/scripts/build-jsc.ts
@@ -2,7 +2,7 @@ import * as esbuild from 'esbuild'
 
 // are we building for the CLI (used for testing)?
 const isCliBuild = process.argv.includes('--cli')
-if(isCliBuild) {
+if (isCliBuild) {
 	console.log('Building for CLI...')
 }
 
@@ -20,7 +20,7 @@ const rslt = await esbuild.build({
 				outfile: 'browser/resources/attestor-jsc.min.mjs'
 			}
 	),
-	format: 'esm',
+	format: isCliBuild ? 'esm' : 'iife',
 	tsconfig: 'tsconfig.build.json',
 	legalComments: 'none',
 	metafile: true, // Enable metafile generation
@@ -47,7 +47,7 @@ const rslt = await esbuild.build({
 	],
 })
 
-if(process.argv.includes('--analyze')) {
+if (process.argv.includes('--analyze')) {
 	// Analyze the metafile
 	const analysis = await esbuild.analyzeMetafile(rslt.metafile)
 	console.log(analysis)


### PR DESCRIPTION
### Description
- Updates global exports for external runtime to make setupFlutterJsRpc, and handleIncomingMessage visible
- Update `src/scripts/build-jsc.ts` to build in iife format when not building with cli flag to support evaluations in js runtimes that don't support loading modules
- Update request id for step updates to original createClaim request's id

### Testing (ignore for documentation update)
- Tested on Chrome, [Apple JavaScriptCore framework](https://developer.apple.com/documentation/javascriptcore/jscontext) and [Android Jetpack JavaScript Engine library](https://developer.android.com/reference/kotlin/androidx/javascriptengine/JavaScriptIsolate)

- Tested against 5 providers: `example`, `3ff41ded-b79f-43b7-82f2-2f3a8d98e565`, `3be7800d-6404-43c4-aad5-23d8420fd0d1`, `3be7800d-6404-43c4-aad5-23d8420fd0d2`, `38a0883e-84ec-48a9-a35f-b1631e0bb6cf`, `ac48fd75-02c0-4fd7-93e2-f2ada1732665`.
- Fails with regex expression error when responseMatch.type is regex for claims created by provider `ac48fd75-02c0-4fd7-93e2-f2ada1732665`. Cannot reproduce this issue on https://attestor.reclaimprotocol.org/browser-rpc. 

<details>
<summary>Failing claim example</summary>

```json
{
        "name": "http",
        "params": {
            "geoLocation": "{{DYNAMIC_GEO}}",
            "url": "https://www.randomnumberapi.com/api/v1.0/random",
            "method": "GET",
            "body": "",
            "headers": {
                "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1",
                "Sec-Fetch-Mode": "same-origin",
                "Sec-Fetch-Site": "same-origin"
            },
            "responseMatches": [
                {
                    "invert": false,
                    "type": "regex",
                    "value": "\\[(?<randomNumber>.*?)]"
                }
            ],
            "responseRedactions": [
                {
                    "jsonPath": "",
                    "regex": "\\[(?<randomNumber>.*?)]",
                    "xPath": ""
                }
            ],
            "paramValues": {
                "DYNAMIC_GEO": "IN",
                "randomNumber": "79"
            },
            "additionalClientOptions": {}
        },
        "secretParams": {
            "headers": {
                "Referer": "https://www.randomnumberapi.com/"
            },
            "cookieStr": "",
            "paramValues": {}
        },
        "sessionId": "9cd21df5a2",
        "context": "",
        "ownerPrivateKey": "0xf721905419e94c9b2dc00d7b19fb408ffbcabef3263221b0a3a59e40a1fd99c2",
        "updateProviderParams": false
    }
```

<img width="470" height="81" alt="Screenshot 2025-08-18 at 3 38 01 AM" src="https://github.com/user-attachments/assets/9c88b4c0-3897-4c04-a651-bbb470490989" />

</details>

### Type of change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:

<details>
<summary>How to reproduce this issue on attestor browser rpc built with this branch compared to https://attestor.reclaimprotocol.org/browser-rpc?</summary>

Try the following script:

```js
globalThis.ConsoleMessenger = { postMessage: (message) => {console.info({ message })} }

globalThis.ConsoleMessenger.postMessage('ok')

globalThis.RPC_CHANNEL_NAME = 'ConsoleMessenger';
globalThis.ATTESTOR_BASE_URL = 'https://attestor.reclaimprotocol.org';

function sendMessage(key, message) {
    globalThis[key].postMessage(message)
}

/// THIS ONE WILL WORK
globalThis.postMessage(JSON.stringify({
    "id": "abc",
    "type": "createClaim",
    "module": "witness-sdk",
    "channel": "ConsoleMessenger",
    "request": {
        "name": "http",
        "params": {
            "url": "https://example.com/",
            "method": "GET",
            "responseMatches": [
                {
                    "type": "contains",
                    "value": "<title>{{domain}}</title>"
                }
            ],
            "responseRedactions": [
                {
                    "xPath": "/html/head/title",
                    "regex": "<title>(?<domain>.*?)</title>"
                }
            ],
            "paramValues": {
                "domain": "Example Domain"
            }
        },
        "secretParams": {
            "cookieStr": "<cookie-str>"
        },
        "sessionId": "ffb54295-66d3-4af3-91d9-df0a92342de4",
        "ownerPrivateKey": "0x447bbf6dcf0f9582a3494b611ccbb94249389652109b475496300f9cf0843dd4",
        "updateProviderParams": false,
        "zkProofConcurrency": 2
    }
}));

/// THIS ONE WILL WORK
globalThis.postMessage(JSON.stringify({
	// this is a random ID you generate,
	// use to match the response to the request
	id: 'def',
	// the type of request you want to make
	type: 'createClaim',
    "module":"witness-sdk",
    "channel": "ConsoleMessenger",
	request: {
		name: 'http',
		params: {
			"url": "https://example.com",
			"method": "GET",
			"responseMatches": [
				{
					"type": "contains",
					"value": "<title>"
				}
			]
		},
		secretParams: {
			cookieStr: '<cookie-str>'
		},
		ownerPrivateKey: '0x447bbf6dcf0f9582a3494b611ccbb94249389652109b475496300f9cf0843dd4',
		// limit ZK proof concurrency
		// to limit memory consumption
		// as webview has max 500mb memory
		zkProofConcurrency: 1,
	}
}));

/// THIS ONE WILL ONLY WORK on https://attestor.reclaimprotocol.org/browser-rpc
globalThis.postMessage(JSON.stringify({
	// this is a random ID you generate,
	// use to match the response to the request
	id: 'hij',
	// the type of request you want to make
	type: 'createClaim',
    "module":"witness-sdk",
    "channel": "ConsoleMessenger",
	request: {
	"name": "http",
	"params": {
		"geoLocation": "{{DYNAMIC_GEO}}",
		"url": "https://www.randomnumberapi.com/api/v1.0/random",
		"method": "GET",
		"body": "",
		"headers": {
			"User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1",
			"Sec-Fetch-Mode": "same-origin",
			"Sec-Fetch-Site": "same-origin"
		},
		"responseMatches": [
			{
				"invert": false,
				"type": "regex",
				"value": "\\[(?<randomNumber>.*?)]"
			}
		],
		"responseRedactions": [
			{
				"jsonPath": "",
				"regex": "\\[(?<randomNumber>.*?)]",
				"xPath": ""
			}
		],
		"paramValues": {
			"DYNAMIC_GEO": "IN",
			"randomNumber": "79"
		},
		"additionalClientOptions": {}
	},
	"secretParams": {
		"headers": {
			"Referer": "https://www.randomnumberapi.com/"
		},
		"cookieStr": "",
		"paramValues": {}
	},
	"sessionId": "9cd21df5a2",
	"context": "",
	"ownerPrivateKey": "0xf721905419e94c9b2dc00d7b19fb408ffbcabef3263221b0a3a59e40a1fd99c2",
	"updateProviderParams": false
}}));
```

</details>
