### PR TITLE
feat: add deployment workflows for production and staging environments

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,0 +1,36 @@
+name: Deploy Attestor to ECS (Production)
+
+on:
+  workflow_run:
+    workflows: ["Build & Publish Docker Image"]
+    branches:
+      - "main"
+    types:
+      - completed
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Dispatch deploy-production on attestor-deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ATTESTOR_DEPLOYMENT_DISPATCH_TOKEN }}
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const headBranch = context.payload.workflow_run.head_branch;
+            console.log(`Build succeeded on branch=${headBranch}, sha=${sha}`);
+            console.log(`Dispatching deploy-production.yml on attestor-deployment...`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'reclaimprotocol',
+              repo: 'attestor-deployment',
+              workflow_id: 'deploy-production.yml',
+              ref: 'main',
+              inputs: {
+                image_tag: `sha-${sha}`,
+              },
+            });
+
+            console.log(`Dispatched deploy-production.yml with image_tag=sha-${sha}`);

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,36 @@
+name: Deploy Attestor to ECS (Staging)
+
+on:
+  workflow_run:
+    workflows: ["Build & Publish Docker Image"]
+    branches:
+      - "release/staging*"
+    types:
+      - completed
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Dispatch deploy-staging on attestor-deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ATTESTOR_DEPLOYMENT_DISPATCH_TOKEN }}
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const headBranch = context.payload.workflow_run.head_branch;
+            console.log(`Build succeeded on branch=${headBranch}, sha=${sha}`);
+            console.log(`Dispatching deploy-staging.yml on attestor-deployment...`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'reclaimprotocol',
+              repo: 'attestor-deployment',
+              workflow_id: 'deploy-staging.yml',
+              ref: 'main',
+              inputs: {
+                image_tag: `sha-${sha}`,
+              },
+            });
+
+            console.log(`Dispatched deploy-staging.yml with image_tag=sha-${sha}`);


### PR DESCRIPTION
### Description
Add cross-repo dispatch workflows that hand off ECS deploys to attestor-deployment after a successful Docker image build.

release/staging* push → build runs → deploy-staging.yaml fires → dispatches deploy-staging.yml on attestor-deployment
main push → build runs → deploy-production.yaml fires → dispatches deploy-production.yml on attestor-deployment
Both pass image_tag=sha-<sha> so the deployment repo pulls the exact image this build pushed to GHCR. Uses a PAT stored as ATTESTOR_DEPLOYMENT_DISPATCH_TOKEN (Actions read+write on attestor-deployment only).

Legacy deploy.yaml is untouched.

### Testing (ignore for documentation update)
<!-- Briefly describe how you've tested this implementation -->

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:
- [ ] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [ ] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [ ] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [ ] I have self-reviewed and tested my code.
- [ ] I have updated documentation as needed.
- [ ] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
<!-- Any other context about the PR. -->
