### PR TITLE
Avoid OOM when signing/verifying large claim payloads

### DIFF
--- a/src/tests/signatures.test.ts
+++ b/src/tests/signatures.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test'
 import { getBytes, hexlify, Wallet } from 'ethers'
 
 import { ServiceSignatureType } from '#src/proto/api.ts'
+import { ETH_SIGNATURE_PROVIDER } from '#src/utils/signatures/eth.ts'
 import { SIGNATURES } from '#src/utils/signatures/index.ts'
 
 const ALGS = [
@@ -36,3 +37,78 @@ for(const { algorithm } of ALGS) {
 		})
 	})
 }
+
+describe('ETH signature parity with wallet.signMessage', () => {
+	it('produces identical bytes to wallet.signMessage for Uint8Array input', async() => {
+		const wallet = Wallet.createRandom()
+		const data = new Uint8Array(1024)
+		for(let i = 0; i < data.length; i++) {
+			data[i] = (i * 31) & 0xff
+		}
+
+		const ours = await ETH_SIGNATURE_PROVIDER.sign(data, wallet.privateKey)
+		const reference = getBytes(await wallet.signMessage(data))
+
+		assert.deepStrictEqual(ours, reference)
+	})
+
+	it('produces identical bytes to wallet.signMessage for string input', async() => {
+		const wallet = Wallet.createRandom()
+		const data = '{"a":"123","b":123,"c":"unicode: π Ω ✓"}'
+
+		const ours = await ETH_SIGNATURE_PROVIDER.sign(data, wallet.privateKey)
+		const reference = getBytes(await wallet.signMessage(data))
+
+		assert.deepStrictEqual(ours, reference)
+	})
+
+	it('signs & verifies multi-megabyte payloads without ethers memory blow-up', async() => {
+		// 8 MB payload. ethers' wallet.signMessage / verifyMessage allocate
+		// ~480 MB of JS heap at this size (60x amplification via hex/string
+		// round-trips). The in-place EIP-191 path should stay well under that
+		// — we cap each heap delta at 80 MB (10x input size) to leave headroom
+		// for V8 fragmentation while still catching a regression to the old
+		// behaviour.
+		const wallet = Wallet.createRandom()
+		const data = new Uint8Array(8 * 1024 * 1024)
+		for(let i = 0; i < 4096; i++) {
+			data[i] = (i * 17) & 0xff
+		}
+
+		if(global.gc) {
+			global.gc()
+		}
+
+		const heapBeforeSign = process.memoryUsage().heapUsed
+		const signature = await ETH_SIGNATURE_PROVIDER.sign(data, wallet.privateKey)
+		const heapAfterSign = process.memoryUsage().heapUsed
+		const signHeapDeltaMb = (heapAfterSign - heapBeforeSign) / 1024 / 1024
+
+		assert.strictEqual(signature.length, 65, 'expected 65-byte ECDSA sig')
+		assert.ok(
+			signHeapDeltaMb < 80,
+			`heap grew by ${signHeapDeltaMb.toFixed(1)} MB while signing 8 MB; `
+				+ 'expected < 80 MB. The sign() implementation may have regressed '
+				+ 'to ethers signMessage which amplifies input size ~60x in memory.'
+		)
+
+		if(global.gc) {
+			global.gc()
+		}
+
+		const heapBeforeVerify = process.memoryUsage().heapUsed
+		const ok = await ETH_SIGNATURE_PROVIDER.verify(
+			data, signature, wallet.address.toLowerCase()
+		)
+		const heapAfterVerify = process.memoryUsage().heapUsed
+		const verifyHeapDeltaMb = (heapAfterVerify - heapBeforeVerify) / 1024 / 1024
+
+		assert.ok(ok, 'signature must verify against the signing wallet')
+		assert.ok(
+			verifyHeapDeltaMb < 80,
+			`heap grew by ${verifyHeapDeltaMb.toFixed(1)} MB while verifying 8 MB; `
+				+ 'expected < 80 MB. The verify() implementation may have regressed '
+				+ 'to ethers verifyMessage which amplifies input size ~60x in memory.'
+		)
+	})
+})

--- a/src/utils/signatures/eth.ts
+++ b/src/utils/signatures/eth.ts
@@ -1,6 +1,8 @@
-import { computeAddress, getBytes, hexlify, SigningKey, verifyMessage, Wallet } from 'ethers'
+import { computeAddress, getBytes, hexlify, keccak256, recoverAddress, SigningKey, toUtf8Bytes, Wallet } from 'ethers'
 
 import type { ServiceSignatureProvider } from '#src/types/index.ts'
+
+const EIP191_PREFIX = toUtf8Bytes('\x19Ethereum Signed Message:\n')
 
 export const ETH_SIGNATURE_PROVIDER: ServiceSignatureProvider = {
 	getPublicKey(privateKey) {
@@ -14,16 +16,21 @@ export const ETH_SIGNATURE_PROVIDER: ServiceSignatureProvider = {
 	},
 	async sign(data, privateKey) {
 		const wallet = getEthWallet(privateKey)
-		const signature = await wallet.signMessage(data)
-		return getBytes(signature)
+		// Equivalent to wallet.signMessage(bytes): same EIP-191 digest, same signature
+		// bytes. Avoids ethers' ~60x heap blow-up on multi-MB payloads (e.g. claim
+		// bundles carrying many STWO proofs) by hashing the message in place instead
+		// of going through hex/string round-trips internally.
+		const sig = wallet.signingKey.sign(eip191Digest(data))
+		return getBytes(sig.serialized)
 	},
 	async verify(data, signature, addressBytes) {
 		const address = typeof addressBytes === 'string'
 			? addressBytes
 			: hexlify(addressBytes)
-		// verifyMessage in v6 expects SignatureLike (hex string)
 		const signatureHex = typeof signature === 'string' ? signature : hexlify(signature)
-		const signerAddress = verifyMessage(data, signatureHex)
+		// Mirror of sign(): recover from the same EIP-191 digest instead of calling
+		// ethers' verifyMessage(data, sig), which has the same ~60x amplification.
+		const signerAddress = recoverAddress(eip191Digest(data), signatureHex)
 		return signerAddress.toLowerCase() === address.toLowerCase()
 	}
 }
@@ -34,4 +41,16 @@ function getEthWallet(privateKey: string) {
 	}
 
 	return new Wallet(privateKey)
+}
+
+function eip191Digest(data: Uint8Array | string): string {
+	const bytes = typeof data === 'string' ? toUtf8Bytes(data) : data
+	const lenBytes = toUtf8Bytes(String(bytes.length))
+	const merged = new Uint8Array(
+		EIP191_PREFIX.length + lenBytes.length + bytes.length
+	)
+	merged.set(EIP191_PREFIX, 0)
+	merged.set(lenBytes, EIP191_PREFIX.length)
+	merged.set(bytes, EIP191_PREFIX.length + lenBytes.length)
+	return keccak256(merged)
 }


### PR DESCRIPTION
## Summary

- `wallet.signMessage` / `verifyMessage` in ethers v6 expand the input ~60x on the JS heap via internal hex/string round-trips, so signing a multi-MB payload allocates hundreds of MB.
- Claim bundles carrying many STWO proofs (each ~1.4MB binary, request can reach ~85MB) blew the default 4GB Node heap during `signatureAlg.sign` in `create-claim.ts` and during `verifySig` in `assertValidClaimRequest`.
- Replace both calls with an in-place EIP-191 personal_sign digest (`keccak256(prefix || len || data)`) and use `signingKey.sign` / `recoverAddress` on the 32-byte digest. The resulting signature bytes are identical, so on-the-wire format and existing verifiers stay unchanged — no protocol break.

Measured before/after for sign:

| input | before (signMessage heap) | after (eip191Digest heap) |
|---|---|---|
| 10 MB | 632 MB | 14 MB |
| 30 MB | 1875 MB | 18 MB |
| 80 MB | **OOM at 4 GB** | n/a (no longer relevant) |

## Repro

`npm run create:claim -- --json example/http1.json --attestor local` against a github.com/settings/profile claim with `xPath: "//script[@id=\"client-env\"]"` (produces 60 STWO ChaCha20 proofs, ~87MB encoded request) previously OOM'd at the default 4GB heap. With this fix it succeeds at 4GB.

## Test plan

- [x] `npm run run:test-files -- --test src/tests/signatures.test.ts` — 4 pass, 0 fail
- [x] `npm run run:test-files -- --test src/tests/http-provider-utils.test.ts src/tests/http-provider.test.ts` — 54 pass, 1 skip, 0 fail (smoke check)
- [x] End-to-end `create:claim` at `NODE_OPTIONS=--max-old-space-size=4096` now succeeds where it previously OOM'd
- [x] New `signatures.test.ts` cases:
  - Byte-equivalence to `wallet.signMessage` for `Uint8Array` input
  - Byte-equivalence to `wallet.signMessage` for `string` input
  - 8 MB sign + verify roundtrip, asserts heap delta stays under 80 MB on each side (catches regression to the old code path)