### PR TITLE
fix(http): honor response charset in matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reclaimprotocol/attestor-core",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reclaimprotocol/attestor-core",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/attestor-core",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "",
   "type": "module",
   "imports": {

--- a/src/providers/http/index.ts
+++ b/src/providers/http/index.ts
@@ -233,6 +233,11 @@ const HTTP_PROVIDER: Provider<'http'> = {
 			reveals.push(res.headerIndices['date'])
 		}
 
+		//reveal content-type so the verifier can decode the response body charset
+		if(res.headerIndices['content-type']) {
+			reveals.push(res.headerIndices['content-type'])
+		}
+
 		//reveal transfer-encoding header so the verifier can dechunk the body
 		if(revealFraming && res.headerIndices['transfer-encoding']) {
 			reveals.push(res.headerIndices['transfer-encoding'])
@@ -358,21 +363,34 @@ const HTTP_PROVIDER: Provider<'http'> = {
 			: allServerBlocks.slice(firstRealIdx)
 		const response = concatArrays(...serverBlocks)
 
-		let res: string
-		res = uint8ArrayToStr(response)
+		let bodyStart: number
+		if(shouldRevealCrlf(ctx)) {
+			const responseAfterStatus = response.slice(OK_HTTP_HEADER.length)
+			const separatorIdx = findIndexInUint8Array(
+				responseAfterStatus,
+				strToUint8Array('\r\n\r\n'),
+			)
+			if(separatorIdx === -1) {
+				throw new Error('Response body start not found')
+			}
 
+			bodyStart = OK_HTTP_HEADER.length + separatorIdx + 4
+		} else {
+			bodyStart = OK_HTTP_HEADER.length
+		}
+		const headersText = uint8ArrayToStr(response.slice(0, bodyStart))
 		const okRegex = makeRegex('^HTTP\\/1.1 2\\d{2}')
-		const matchRes = okRegex.exec(res)
+		const matchRes = okRegex.exec(headersText)
 		if(!matchRes) {
 			const statusRegex = makeRegex('^HTTP\\/1.1 (\\d{3})')
-			const matchRes = statusRegex.exec(res)
+			const matchRes = statusRegex.exec(headersText)
 			if(matchRes && matchRes.length > 1) {
 				throw new Error(`Provider returned error ${matchRes[1]}`)
 			}
 
-			let lineEnd = res.indexOf('*')
+			let lineEnd = headersText.indexOf('*')
 			if(lineEnd === -1) {
-				lineEnd = res.indexOf('\n')
+				lineEnd = headersText.indexOf('\n')
 			}
 
 			if(lineEnd === -1) {
@@ -380,19 +398,33 @@ const HTTP_PROVIDER: Provider<'http'> = {
 			}
 
 			throw new Error(
-				`Response did not start with \"HTTP/1.1 2XX\" got "${res.slice(0, lineEnd)}"`
+				`Response did not start with \"HTTP/1.1 2XX\" got "${headersText.slice(0, lineEnd)}"`
 			)
 		}
 
-		let bodyStart: number
-		if(shouldRevealCrlf(ctx)) {
-			bodyStart = res.indexOf('\r\n\r\n', OK_HTTP_HEADER.length) + 4
-			if(bodyStart < 4) {
-				throw new Error('Response body start not found')
-			}
-		} else {
-			bodyStart = OK_HTTP_HEADER.length
+		const paramBody = params.body instanceof Uint8Array
+			? params.body
+			: strToUint8Array(params.body || '')
+
+		if(paramBody.length > 0 && !matchRedactedStrings(paramBody, req.body)) {
+			throw new Error('request body mismatch')
 		}
+
+
+		let body: Uint8Array = response.slice(bodyStart)
+		if(shouldRevealChunkFraming(clientVersion)) {
+			//dechunk the body so matches see contiguous content; redaction
+			//asterisks are preserved as boundaries between revealed slices
+			if(/transfer-encoding:\s*chunked/i.test(headersText)) {
+				body = dechunkResponseBody(body)
+			}
+		}
+
+		const charset = shouldRevealCrlf(ctx)
+			? getResponseBodyCharset(headersText)
+			: undefined
+		const bodyText = decodeResponseBody(body, charset)
+		let res = headersText + bodyText
 
 		//validate server Date header if present
 		const dateHeader = makeRegex(dateHeaderRegex).exec(res)
@@ -409,24 +441,7 @@ const HTTP_PROVIDER: Provider<'http'> = {
 			}
 		}
 
-
-		const paramBody = params.body instanceof Uint8Array
-			? params.body
-			: strToUint8Array(params.body || '')
-
-		if(paramBody.length > 0 && !matchRedactedStrings(paramBody, req.body)) {
-			throw new Error('request body mismatch')
-		}
-
-
-		if(shouldRevealChunkFraming(clientVersion)) {
-			//dechunk the body so matches see contiguous content; redaction
-			//asterisks are preserved as boundaries between revealed slices
-			const headersStr = res.slice(0, bodyStart)
-			res = /transfer-encoding:\s*chunked/i.test(headersStr)
-				? headersStr + dechunkResponseBody(res.slice(bodyStart))
-				: res
-		} else if(!secretParams) {
+		if(!shouldRevealChunkFraming(clientVersion) && !secretParams) {
 			//legacy clients redact chunk framing; collapse asterisk runs so
 			//matches can span the redacted framing
 			res = res.slice(bodyStart).replace(/\*{3,}/g, '')
@@ -554,14 +569,45 @@ function shouldRevealChunkFraming(version: AttestorVersion) {
 	return version >= AttestorVersion.ATTESTOR_VERSION_3_2_0
 }
 
-// dechunk a revealed body by reusing the parser: wrap it in a minimal
-// (already-validated) header block. streamEnded() skipped to tolerate trailing bytes
-function dechunkResponseBody(body: string) {
+function getResponseBodyCharset(headers: string) {
+	const contentType = /(?:^|[\r\n*])content-type\s*:\s*([^*\r\n]*)/i
+		.exec(headers)?.[1]
+	if(typeof contentType === 'undefined') {
+		return undefined
+	}
+
+	const charsetMatch = /(?:^|;)\s*charset\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^;\s]*))/i
+		.exec(contentType)
+	if(!charsetMatch) {
+		return undefined
+	}
+
+	const charset = charsetMatch[1]?.replace(/\\(.)/g, '$1') ?? charsetMatch[2]
+	return charset.trim() || undefined
+}
+
+function decodeResponseBody(body: Uint8Array, charset: string | undefined) {
+	try {
+		return new TextDecoder(charset ?? 'utf-8').decode(body)
+	} catch(error) {
+		if(charset) {
+			throw new Error(`Unsupported response charset "${charset}"`, { cause: error })
+		}
+
+		throw error
+	}
+}
+
+// dechunk a revealed body by reusing the byte-oriented parser: wrap it in a
+// minimal (already-validated) header block. streamEnded() is skipped to
+// tolerate trailing bytes.
+function dechunkResponseBody(body: Uint8Array) {
 	const parser = makeHttpResponseParser()
-	parser.onChunk(
-		strToUint8Array('HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n' + body)
-	)
-	return uint8ArrayToStr(parser.res.body ?? new Uint8Array())
+	parser.onChunk(concatenateUint8Arrays([
+		strToUint8Array('HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n'),
+		body,
+	]))
+	return parser.res.body ?? new Uint8Array()
 }
 
 function getHostPort(params: ProviderParams<'http'>, secretParams: ProviderSecretParams<'http'>) {

--- a/src/tests/http-provider-utils.test.ts
+++ b/src/tests/http-provider-utils.test.ts
@@ -192,11 +192,11 @@ describe('HTTP Provider Utils tests', () => {
 		})
 		const redacted = uint8ArrayToStr(redactSlices(simpleChunk, redactions))
 
-		// chunk framing + transfer-encoding header are revealed verbatim
+		// content-type, chunk framing, and transfer-encoding are revealed verbatim
+		assert.ok(redacted.includes('Content-Type: text/plain'))
 		assert.ok(redacted.includes('Transfer-Encoding: chunked'))
 		assert.ok(redacted.includes('9\r\nchunk 1, \r\n7\r\nchunk 2\r\n0\r\n'))
 		// other headers stay redacted
-		assert.ok(!redacted.includes('Content-Type'))
 		assert.ok(!redacted.includes('Connection'))
 	})
 
@@ -309,6 +309,195 @@ describe('HTTP Provider Utils tests', () => {
 		})
 	})
 
+	it('matches ISO-8859-1 response text with contains', async() => {
+		const body = Buffer.from([0x53, 0x65, 0xf1, 0x6f, 0x72])
+		const params = charsetMatchParams('contains', 'Señor')
+		const { receipt } = getReceiptForResponse(
+			responseWithBody(body, 'text/plain; charset=ISO-8859-1'),
+			params,
+		)
+
+		await assertValidProviderReceipt({
+			receipt,
+			clientVersion: CURRENT_ATTESTOR_VERSION,
+			params,
+			logger,
+			ctx,
+		})
+	})
+
+	it('matches ISO-8859-1 response text with regex', async() => {
+		const body = Buffer.from([0x53, 0x65, 0xf1, 0x6f, 0x72])
+		const params = charsetMatchParams('regex', 'Señor')
+		const { receipt } = getReceiptForResponse(
+			responseWithBody(body, 'text/plain; charset=ISO-8859-1'),
+			params,
+		)
+
+		await assertValidProviderReceipt({
+			receipt,
+			clientVersion: CURRENT_ATTESTOR_VERSION,
+			params,
+			logger,
+			ctx,
+		})
+	})
+
+	it('extracts named regex groups from decoded ISO-8859-1 text', async() => {
+		const body = Buffer.from([0x53, 0x65, 0xf1, 0x6f, 0x72])
+		const params = charsetMatchParams('regex', '(?<name>Señor)')
+		const { receipt } = getReceiptForResponse(
+			responseWithBody(body, 'text/plain; charset=ISO-8859-1'),
+			params,
+		)
+
+		const result = await assertValidProviderReceipt({
+			receipt,
+			clientVersion: CURRENT_ATTESTOR_VERSION,
+			params,
+			logger,
+			ctx,
+		})
+
+		assert.equal(result!.extractedParameters.name, 'Señor')
+	})
+
+	it('dechunks ISO-8859-1 bytes before response matching', async() => {
+		const body = Buffer.from([0x53, 0x65, 0xf1, 0x6f, 0x72])
+		const response = Buffer.concat([
+			Buffer.from(
+				'HTTP/1.1 200 OK\r\n'
+				+ 'Content-Type: text/plain; charset=ISO-8859-1\r\n'
+				+ 'Transfer-Encoding: chunked\r\n'
+				+ 'X-Unrelated: secret\r\n\r\n'
+			),
+			Buffer.from('2\r\n'),
+			body.subarray(0, 2),
+			Buffer.from('\r\n3\r\n'),
+			body.subarray(2),
+			Buffer.from('\r\n0\r\n'),
+		])
+		const params = charsetMatchParams('contains', 'Señor')
+		const { receipt } = getReceiptForResponse(response, params)
+
+		await assertValidProviderReceipt({
+			receipt,
+			clientVersion: CURRENT_ATTESTOR_VERSION,
+			params,
+			logger,
+			ctx,
+		})
+	})
+
+	it('preserves response matching for valid UTF-8', async() => {
+		const body = Buffer.from('Señor', 'utf8')
+		const params: ProviderParams<'http'> = {
+			url: 'https://xargs.org/',
+			method: 'GET',
+			responseMatches: [{ type: 'contains', value: 'Señor' }],
+			responseRedactions: [{ regex: 'SeÃ±or' }],
+		}
+		const { receipt } = getReceiptForResponse(
+			responseWithBody(body, 'text/plain; charset=UTF-8'),
+			params,
+		)
+
+		await assertValidProviderReceipt({
+			receipt,
+			clientVersion: CURRENT_ATTESTOR_VERSION,
+			params,
+			logger,
+			ctx,
+		})
+	})
+
+	it('uses UTF-8 when the header Content-Type has no charset', async() => {
+		const body = Buffer.from(
+			'Content-Type: text/plain; charset=not-a-charset Señor',
+			'utf8',
+		)
+		const params: ProviderParams<'http'> = {
+			url: 'https://xargs.org/',
+			method: 'GET',
+			responseMatches: [{ type: 'regex', value: 'Señor' }],
+			responseRedactions: [{
+				regex: 'Content-Type: text/plain; charset=not-a-charset SeÃ±or'
+			}],
+		}
+		const { receipt } = getReceiptForResponse(
+			responseWithBody(body, 'text/plain'),
+			params,
+		)
+
+		await assertValidProviderReceipt({
+			receipt,
+			clientVersion: CURRENT_ATTESTOR_VERSION,
+			params,
+			logger,
+			ctx,
+		})
+	})
+
+	it('reveals the complete Content-Type value and no unrelated headers', () => {
+		const body = Buffer.from([0x53, 0x65, 0xf1, 0x6f, 0x72])
+		const params = charsetMatchParams('contains', 'Señor')
+		const { redactedResponse } = getReceiptForResponse(
+			responseWithBody(
+				body,
+				'text/plain; charset=ISO-8859-1',
+				['X-Unrelated: keep-secret'],
+			),
+			params,
+		)
+		const redactedText = Buffer.from(redactedResponse).toString('latin1')
+
+		assert.ok(redactedText.includes('Content-Type: text/plain; charset=ISO-8859-1'))
+		assert.ok(!redactedText.includes('X-Unrelated'))
+	})
+
+	it('preserves selectively hidden body bytes as asterisks while decoding', async() => {
+		const body = Buffer.from([0x78, 0x53, 0x65, 0xf1, 0x6f, 0x72])
+		const params = charsetMatchParams('contains', '*Señor')
+		const { receipt, redactedResponse } = getReceiptForResponse(
+			responseWithBody(body, 'text/plain; charset=ISO-8859-1'),
+			params,
+		)
+
+		assert.equal(redactedResponse[redactedResponse.length - body.length], '*'.charCodeAt(0))
+		await assertValidProviderReceipt({
+			receipt,
+			clientVersion: CURRENT_ATTESTOR_VERSION,
+			params,
+			logger,
+			ctx,
+		})
+	})
+
+	it('rejects an unsupported declared response charset', async() => {
+		const body = Buffer.from('needle')
+		const params: ProviderParams<'http'> = {
+			url: 'https://xargs.org/',
+			method: 'GET',
+			responseMatches: [{ type: 'contains', value: 'needle' }],
+			responseRedactions: [{ regex: 'needle' }],
+		}
+		const { receipt } = getReceiptForResponse(
+			responseWithBody(body, 'text/plain; charset=not-a-charset'),
+			params,
+		)
+
+		await assert.rejects(
+			async() => assertValidProviderReceipt({
+				receipt,
+				clientVersion: CURRENT_ATTESTOR_VERSION,
+				params,
+				logger,
+				ctx,
+			}),
+			/Unsupported response charset "not-a-charset"/
+		)
+	})
+
 	it.skip('should redact non-ASCII chars via regex', () => {
 		const provider = httpProvider
 		const text = '秘密の情報' // some non-ASCII text
@@ -363,6 +552,10 @@ describe('HTTP Provider Utils tests', () => {
 		assert.deepEqual(redactions, [
 			{
 				'fromIndex': 15,
+				'toIndex': 17,
+			},
+			{
+				'fromIndex': 41,
 				'toIndex': 81,
 			},
 			{
@@ -414,7 +607,7 @@ describe('HTTP Provider Utils tests', () => {
 			start = red.toIndex
 		}
 
-		assert.equal(str, 'HTTP/1.1 200 OK\r\n\r\n262728272829293031')
+		assert.equal(str, 'HTTP/1.1 200 OKContent-Type: text/plain\r\n\r\n262728272829293031')
 	})
 
 	it('should perform complex redactions 2', () => {
@@ -443,6 +636,10 @@ describe('HTTP Provider Utils tests', () => {
 			assert.deepEqual(redactions, [
 				{
 					'fromIndex': 15,
+					'toIndex': 17,
+				},
+				{
+					'fromIndex': 41,
 					'toIndex': 80,
 				},
 				{
@@ -470,7 +667,7 @@ describe('HTTP Provider Utils tests', () => {
 				start = red.toIndex
 			}
 
-			assert.equal(str, 'HTTP/1.1 200 OK\r\n\r\n262728')
+			assert.equal(str, 'HTTP/1.1 200 OKContent-Type: text/plain\r\n\r\n262728')
 		}
 
 	})
@@ -499,6 +696,10 @@ describe('HTTP Provider Utils tests', () => {
 			assert.deepEqual(redactions, [
 				{
 					'fromIndex': 15,
+					'toIndex': 17,
+				},
+				{
+					'fromIndex': 41,
 					'toIndex': 81,
 				},
 				{
@@ -526,7 +727,7 @@ describe('HTTP Provider Utils tests', () => {
 				start = red.toIndex
 			}
 
-			assert.equal(str, 'HTTP/1.1 200 OK\r\n\r\n"age":"26""age":"27""age":"29"')
+			assert.equal(str, 'HTTP/1.1 200 OKContent-Type: text/plain\r\n\r\n"age":"26""age":"27""age":"29"')
 		}
 	})
 
@@ -558,12 +759,13 @@ describe('HTTP Provider Utils tests', () => {
 				logger,
 				ctx,
 			})
-			// gaps vs. the legacy snapshot are the now-revealed transfer-encoding
-			// header (94-120) and chunk-size framing lines (4294-4300, 35451-35459,
-			// 64086+); the rest of the redactions are unchanged
+			// gaps vs. the legacy snapshot are the now-revealed content-type header
+			// (54-92), transfer-encoding header (94-120), and chunk-size framing
+			// lines (4294-4300, 35451-35459, 64086+)
 			assert.deepEqual(redactions, [
 				{ fromIndex: 15, toIndex: 17 },
-				{ fromIndex: 52, toIndex: 94 },
+				{ fromIndex: 52, toIndex: 54 },
+				{ fromIndex: 92, toIndex: 94 },
 				{ fromIndex: 120, toIndex: 4290 },
 				{ fromIndex: 4300, toIndex: 4760 },
 				{ fromIndex: 4820, toIndex: 35451 },
@@ -1419,6 +1621,54 @@ Content-Type: text/html; charset=utf-8\r
 			return uint8ArrayToStr((req.data as Uint8Array).slice(req.redactions[index].fromIndex, req.redactions[index].toIndex))
 		}
 	})
+
+	function charsetMatchParams(
+		type: 'contains' | 'regex',
+		value: string,
+	): ProviderParams<'http'> {
+		return {
+			url: 'https://xargs.org/',
+			method: 'GET',
+			responseMatches: [{ type, value }],
+			responseRedactions: [{ regex: 'Señor' }],
+		}
+	}
+
+	function responseWithBody(
+		body: Uint8Array,
+		contentType: string,
+		extraHeaders: string[] = [],
+	) {
+		const headers = Buffer.from([
+			'HTTP/1.1 200 OK',
+			`Content-Type: ${contentType}`,
+			`Content-Length: ${body.length}`,
+			...extraHeaders,
+			'',
+			'',
+		].join('\r\n'))
+
+		return Buffer.concat([headers, body])
+	}
+
+	function getReceiptForResponse(
+		response: Uint8Array,
+		params: ProviderParams<'http'>,
+	) {
+		const redactions = getResponseRedactions!({ response, params, logger, ctx })
+		const redactedResponse = redactSlices(response, redactions)
+		const clone = cloneObject(transcript)
+		const responseIndex = clone.findIndex(
+			block => block.sender === 'server'
+				&& uint8ArrayToStr(block.message).startsWith('HTTP/1.1')
+		)
+		const receipt: Transcript<Uint8Array> = [
+			...clone.slice(0, responseIndex),
+			{ sender: 'server', message: redactedResponse },
+		]
+
+		return { receipt, redactedResponse }
+	}
 
 	async function getRedactedStr(
 		plaintext: Uint8Array,


### PR DESCRIPTION
### Description

- Keep reconstructed HTTP response bodies as bytes through extraction and dechunking.
- Decode the body with the authenticated `Content-Type` charset before `responseMatches.contains` and `responseMatches.regex` validation.
- Reveal only the complete `Content-Type` response-header range in the client path, while preserving unrelated redactions and legacy behavior.
- Reject unsupported declared charsets with a clear validation error.
- Bump the package version from 5.1.1 to 5.1.2.

### Testing (ignore for documentation update)

- `npm run run:test-files -- --test src/tests/http-provider-utils.test.ts` — pass
- `npm run lint` — pass
- `npm run build` — pass
- `npm test` — 147 pass, 2 skip, 1 environmental failure: the invalid-DNS claim-creation test expected `ENOTFOUND` but received the configured server timeout

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:

- [ ] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [ ] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [ ] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [ ] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:

The branch was fetched and verified against `origin/main` immediately before push: 0 commits behind and 1 commit ahead.
