### PR TITLE
fix(zk): handle cross-packet OPRF raw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reclaimprotocol/attestor-core",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reclaimprotocol/attestor-core",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/attestor-core",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "",
   "type": "module",
   "imports": {

--- a/src/client/create-claim.ts
+++ b/src/client/create-claim.ts
@@ -530,14 +530,16 @@ async function _createClaimOnAttestor<N extends ProviderName>(
 				}
 
 				const {
-					block, redactedPlaintext, overshotToprfFromPrevBlock, toprfs, oprfRawMarkers
+					block, redactedPlaintext, overshotToprfFromPrevBlock,
+					overshotOprfRawFromPrevBlock, toprfs, oprfRawMarkers
 				} = reveal
 				setRevealOfMessage(block.message, {
 					type: 'zk',
 					redactedPlaintext,
 					toprfs,
 					oprfRawMarkers,
-					overshotToprfFromPrevBlock
+					overshotToprfFromPrevBlock,
+					overshotOprfRawFromPrevBlock
 				})
 				revealedPackets.push(
 					{ sender: 'server', message: redactedPlaintext }

--- a/src/server/utils/assert-valid-claim-request.ts
+++ b/src/server/utils/assert-valid-claim-request.ts
@@ -412,9 +412,12 @@ export async function decryptTranscript(
 
 			// Process oprf-raw markers: compute OPRF server-side and replace with nullifier
 			if(result.oprfRawMarkers?.length) {
+				const applicationPlaintextLength = tlsVersion === 'TLS1_3'
+					? plaintext.length - 1
+					: plaintext.length
 				const { markersThisPacket, pendingMarker } = separateOprfRawMarkers(
 					result.oprfRawMarkers,
-					plaintext.length,
+					applicationPlaintextLength,
 					() => transcript.findIndex((t, j) => t.sender === sender && j > i),
 					decryptedTranscript.length,
 					logger
@@ -424,7 +427,10 @@ export async function decryptTranscript(
 				if(pendingMarker) {
 					// Copy partial data from plaintext
 					pendingMarker.pending.partialData.set(
-						plaintext.slice(pendingMarker.pending.dataLocation.fromIndex)
+						plaintext.slice(
+							pendingMarker.pending.dataLocation.fromIndex,
+							applicationPlaintextLength
+						)
 					)
 					pendingOprfRaw[pendingMarker.nextIdx] = pendingMarker.pending
 				}

--- a/src/tests/claim-creation.test.ts
+++ b/src/tests/claim-creation.test.ts
@@ -204,6 +204,30 @@ describeWithServer('Claim Creation', opts => {
 			// OPRF cross-packet validation is done server-side
 		})
 
+		it('should create claim with OPRF raw spread across multiple packets', async() => {
+			const user = 'abcd_test_user'
+			const result = await createClaimOnAttestor({
+				name: 'http',
+				params: {
+					url: claimUrl + '?splitDataAcrossPackets=true',
+					method: 'GET',
+					responseRedactions: [
+						{ regex: 'emailAddress\":\"(?<test>[a-z_]+)@', hash: 'oprf-raw' }
+					],
+					responseMatches: [{ type: 'contains', value: '' }]
+				},
+				secretParams: {
+					authorisationHeader: `Bearer ${user}`
+				},
+				ownerPrivateKey: opts.privateKeyHex,
+				client,
+				zkEngine: 'stwo',
+			})
+
+			assert.ok(!result.error)
+			assert.ok(result.claim)
+		})
+
 		it('should produce the same hash for the same input', async() => {
 
 			let hash: Uint8Array | undefined


### PR DESCRIPTION
## Summary

- propagate OPRF raw continuation lengths into ZK packet reveals
- exclude the TLS 1.3 content-type suffix from cross-packet OPRF input
- add a split-packet STWO regression test and bump the package to 5.1.3

## Verification

- reported create:claim command: passed with a valid claim
- focused cross-packet OPRF raw regression: passed
- targeted ESLint: passed
- build TypeScript no-emit check: passed
- full claim-creation test file: 12 of 13 passed; the unrelated unreachable-host test expected ENOTFOUND but received Server connection timed out in this environment