### PR TITLE
fix(snp): bind AWS evidence to one guest

### DIFF
--- a/src/server/utils/sev-snp/allowlist.ts
+++ b/src/server/utils/sev-snp/allowlist.ts
@@ -14,8 +14,10 @@ import { SNP_BASE_PREFIX } from '#src/server/utils/sev-snp/verify.ts'
 
 // Per-cloud base UKI (snp-base:<hex(PCR11)>). GCP = SHA-256, AWS = SHA-384.
 const BAKED_BASES = [
-	'snp-base:e51ea77d7a1a7b435e1141e1f8de1cf3cbbabf9602cad6e060b80c4029f36ff6', // GCP
-	'snp-base:4832908152fc6619b45bdfe6cddb3399c73101cb323983f10923c6c871b19cd92cd08c6d54064840e108566f4d84f6d7', // AWS (pinned base)
+	'snp-base:e51ea77d7a1a7b435e1141e1f8de1cf3cbbabf9602cad6e060b80c4029f36ff6', // GCP legacy
+	'snp-base:4832908152fc6619b45bdfe6cddb3399c73101cb323983f10923c6c871b19cd92cd08c6d54064840e108566f4d84f6d7', // AWS legacy
+	'snp-base:848bc6bf294c76d2002ee313d8994a1601fa4ed478a017d0b3cc7a50a30bfc11', // GCP Go 1.27 base
+	'snp-base:5451db58f0e355b07a81c4b7f0675cc1f2c27d91e82f564837ab92afd2b32c68f190486995677b5162cd7c6f1cade1b5', // AWS same-guest broker base
 ]
 
 function buildBaseSet(): Set<string> {

--- a/src/server/utils/sev-snp/verify.test.ts
+++ b/src/server/utils/sev-snp/verify.test.ts
@@ -8,9 +8,11 @@ import { assertSevSnpBaseAllowed } from '#src/server/utils/sev-snp/allowlist.ts'
 import { verifyNitroTpmDocument } from '#src/server/utils/sev-snp/nitrotpm.ts'
 import { verifySevReport } from '#src/server/utils/sev-snp/sev-report.ts'
 import {
+	awsCombinedV2ReportData,
 	expectedPCR8,
 	extractTeeKeyFromNonces,
 	parseSevSnpEnvelope,
+	requireAwsAttestationV2,
 	SEV_TAG_AWS,
 	SEV_TAG_GCP,
 	snpNonceCommitment,
@@ -103,6 +105,57 @@ test('AWS combined: end-to-end verifyCombinedSevSnp reproduces (app, base, nonce
 	assert.equal(r.nonces.length, 2)
 })
 
+test('AWS v2 commitment binds the caller, app hash, and exact NitroTPM document', () => {
+	const bound = Buffer.from('bound')
+	const app = Buffer.alloc(32, 0x42)
+	const doc = Buffer.from('signed NitroTPM document')
+	const expected = awsCombinedV2ReportData(bound, app, doc)
+
+	assert.notDeepEqual(awsCombinedV2ReportData(Buffer.from('other'), app, doc), expected)
+	assert.notDeepEqual(awsCombinedV2ReportData(bound, Buffer.alloc(32, 0x43), doc), expected)
+	assert.notDeepEqual(awsCombinedV2ReportData(bound, app, Buffer.from('other')), expected)
+})
+
+test('AWS v2 policy rejects a legacy envelope', async() => {
+	const att = loadFixture('aws_combined.b64')
+	const { env } = await parseSevSnpEnvelope(att)
+	const now = await nitroLeafMidValidity(env.nitrotpm!)
+	const prior = process.env.SNP_AWS_ATTESTATION_V2_REQUIRED
+	process.env.SNP_AWS_ATTESTATION_V2_REQUIRED = '1'
+	try {
+		await assert.rejects(verifyCombinedSevSnp(att, now), /no same-guest v2 proof/)
+	} finally {
+		if(prior === undefined) {
+			delete process.env.SNP_AWS_ATTESTATION_V2_REQUIRED
+		} else {
+			process.env.SNP_AWS_ATTESTATION_V2_REQUIRED = prior
+		}
+	}
+})
+
+test('AWS expansion rejects an invalid sev2 report when legacy sev is valid', async() => {
+	const legacy = loadFixture('aws_combined.b64')
+	const { tag, env } = await parseSevSnpEnvelope(legacy)
+	const { encode } = await import('cbor-x')
+	const expanded = Buffer.concat([
+		Buffer.from([tag]),
+		Buffer.from(encode({ ...env, sev2: env.sev })),
+	])
+	const now = await nitroLeafMidValidity(env.nitrotpm!)
+	await assert.rejects(
+		verifyCombinedSevSnp(expanded, now),
+		/report_data does not match expected binding/
+	)
+})
+
+test('AWS v2 policy fails secure on configuration typos', () => {
+	assert.equal(requireAwsAttestationV2(undefined), false)
+	assert.equal(requireAwsAttestationV2('0'), false)
+	assert.equal(requireAwsAttestationV2('1'), true)
+	assert.equal(requireAwsAttestationV2('true'), true)
+	assert.equal(requireAwsAttestationV2('typo'), true)
+})
+
 test('GCP combined: end-to-end verifyCombinedSevSnp reproduces (app, base, nonces)', async() => {
 	const att = loadFixture('gcp_combined.b64')
 	const r = await verifyCombinedSevSnp(att)
@@ -116,5 +169,7 @@ test('GCP combined: end-to-end verifyCombinedSevSnp reproduces (app, base, nonce
 test('allowlist: pins both per-cloud base hashes and rejects unknown ones', () => {
 	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:e51ea77d7a1a7b435e1141e1f8de1cf3cbbabf9602cad6e060b80c4029f36ff6'))
 	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:4832908152fc6619b45bdfe6cddb3399c73101cb323983f10923c6c871b19cd92cd08c6d54064840e108566f4d84f6d7'))
+	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:848bc6bf294c76d2002ee313d8994a1601fa4ed478a017d0b3cc7a50a30bfc11'))
+	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:5451db58f0e355b07a81c4b7f0675cc1f2c27d91e82f564837ab92afd2b32c68f190486995677b5162cd7c6f1cade1b5'))
 	assert.throws(() => assertSevSnpBaseAllowed('snp-base:' + 'ad'.repeat(32)), /base hash/)
 })

--- a/src/server/utils/sev-snp/verify.ts
+++ b/src/server/utils/sev-snp/verify.ts
@@ -18,6 +18,8 @@ export const SEV_TAG_AWS = 0x02
 export const SNP_APP_PREFIX = 'snp-app:'
 export const SNP_BASE_PREFIX = 'snp-base:'
 
+const AWS_V2_DOMAIN = Buffer.from('reclaim/aws-combined-attestation/v2\0', 'utf8')
+
 // Two-tier code identity PCRs: 8 = app bundle (loader-measured), 11 = base UKI.
 export const APP_PCR = 8
 export const BASE_PCR = 11
@@ -27,6 +29,7 @@ export interface SevSnpEnvelope {
 	tpm?: Uint8Array // GCP: go-tpm-tools Attestation proto
 	nitrotpm?: Uint8Array // AWS: NitroTPM COSE_Sign1 document
 	sev?: Uint8Array // AWS + GCP: go-sev-guest Attestation proto
+	sev2?: Uint8Array // AWS: same-guest report bound to the exact NitroTPM document
 	nonces?: string[]
 }
 
@@ -73,6 +76,32 @@ export function snpNonceCommitment(nonces: string[]): Buffer {
 	return h.digest()
 }
 
+/** Commits the AMD report to the exact NitroTPM evidence from the same broker. */
+export function awsCombinedV2ReportData(
+	bound: Uint8Array,
+	appHash: Uint8Array,
+	nitroTpm: Uint8Array
+): Buffer {
+	const h = createHash('sha512')
+	const len8 = Buffer.alloc(8)
+	h.update(AWS_V2_DOMAIN)
+	for(const field of [bound, appHash, nitroTpm]) {
+		len8.writeBigUInt64BE(BigInt(field.length))
+		h.update(len8)
+		h.update(field)
+	}
+
+	return h.digest()
+}
+
+/** Only an absent value or an explicit 0 keeps the AWS expansion path active. */
+export function requireAwsAttestationV2(
+	value: string | undefined = process.env.SNP_AWS_ATTESTATION_V2_REQUIRED
+): boolean {
+	const normalized = value?.trim() ?? ''
+	return normalized !== '' && normalized !== '0'
+}
+
 /**
  * expectedPCR8: the value the loader produces by extending a pristine (all-zero)
  * PCR 8 once with alg(appHash), i.e. alg(0^algSize || alg(appHash)). GCP uses the
@@ -110,23 +139,30 @@ export function extractTeeKeyFromNonces(
 	throw new Error('no tee_[kt]_public_key nonce in SEV-SNP attestation')
 }
 
-// AWS leg: SEV report binds sha512(bound); NitroTPM doc's user_data binds the
-// same; PCR8 proves the app hash (SHA-384 bank); PCR11 is the base.
+// AWS expansion keeps the legacy caller-bound report and adds sev2. The sev2
+// report binds the exact NitroTPM document, app hash, and caller value.
 async function verifyAwsLeg(
 	env: SevSnpEnvelope,
 	bound: Buffer,
 	now: Date
 ): Promise<{ app: string, base: string }> {
-	if(!env.sev || !env.nitrotpm) {
-		throw new Error('AWS SEV-SNP envelope missing sev report or nitrotpm doc')
+	if(!env.nitrotpm || (!env.sev && !env.sev2)) {
+		throw new Error('AWS SEV-SNP envelope missing SEV report or NitroTPM document')
 	}
 
 	const bind = createHash('sha512').update(bound).digest()
-	verifySevReport(env.sev, bind, now)
-
 	const { pcr8, pcr11, userData } = await verifyNitroTpmDocument(env.nitrotpm, now)
 	if(!userData.equals(bind)) {
 		throw new Error('NitroTPM user_data does not bind the attestation')
+	}
+	if(env.sev) {
+		verifySevReport(env.sev, bind, now)
+	}
+	if(env.sev2) {
+		const v2 = awsCombinedV2ReportData(bound, env.app, env.nitrotpm)
+		verifySevReport(env.sev2, v2, now)
+	} else if(requireAwsAttestationV2()) {
+		throw new Error('AWS combined attestation has no same-guest v2 proof')
 	}
 
 	if(!pcr8.equals(expectedPCR8(env.app, 'sha384'))) {


### PR DESCRIPTION
## Summary

- verify AWS `sev2` evidence against a domain-separated commitment to the caller binding, app hash, and exact NitroTPM document
- retain legacy AWS evidence during the expansion rollout while rejecting an invalid `sev2` whenever it is present
- add the new GCP and AWS base identities to the attestor allowlist
- leave the GCP verification path unchanged

## Rollout

Keep `SNP_AWS_ATTESTATION_V2_REQUIRED=0` while old AWS bases remain. After every AWS producer emits valid `sev2`, set it to `1` on the attestor and other central verifiers.

## Validation

- focused SEV-SNP verifier tests: 11 passed
- `npm run lint -- --quiet`
- `npm run build`
- full local suite: 147 passed, 2 skipped; one unrelated DNS-error test reached its timeout instead of receiving `ENOTFOUND`, and one connection timing assertion passed when rerun alone