### PR TITLE
fix(snp): replace undeployed AWS base

### DIFF
--- a/src/server/utils/sev-snp/allowlist.ts
+++ b/src/server/utils/sev-snp/allowlist.ts
@@ -17,7 +17,7 @@ const BAKED_BASES = [
 	'snp-base:e51ea77d7a1a7b435e1141e1f8de1cf3cbbabf9602cad6e060b80c4029f36ff6', // GCP legacy
 	'snp-base:4832908152fc6619b45bdfe6cddb3399c73101cb323983f10923c6c871b19cd92cd08c6d54064840e108566f4d84f6d7', // AWS legacy
 	'snp-base:848bc6bf294c76d2002ee313d8994a1601fa4ed478a017d0b3cc7a50a30bfc11', // GCP Go 1.27 base
-	'snp-base:5451db58f0e355b07a81c4b7f0675cc1f2c27d91e82f564837ab92afd2b32c68f190486995677b5162cd7c6f1cade1b5', // AWS same-guest broker base
+	'snp-base:4d71bf678bf86d7fd81e57f94ecc6203d5c00ab10331e95b7642d5f114606e4a99ba7c1946e18b3726e974a0c8f8f1cb', // AWS same-guest broker base
 ]
 
 function buildBaseSet(): Set<string> {

--- a/src/server/utils/sev-snp/verify.test.ts
+++ b/src/server/utils/sev-snp/verify.test.ts
@@ -170,6 +170,6 @@ test('allowlist: pins both per-cloud base hashes and rejects unknown ones', () =
 	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:e51ea77d7a1a7b435e1141e1f8de1cf3cbbabf9602cad6e060b80c4029f36ff6'))
 	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:4832908152fc6619b45bdfe6cddb3399c73101cb323983f10923c6c871b19cd92cd08c6d54064840e108566f4d84f6d7'))
 	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:848bc6bf294c76d2002ee313d8994a1601fa4ed478a017d0b3cc7a50a30bfc11'))
-	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:5451db58f0e355b07a81c4b7f0675cc1f2c27d91e82f564837ab92afd2b32c68f190486995677b5162cd7c6f1cade1b5'))
+	assert.doesNotThrow(() => assertSevSnpBaseAllowed('snp-base:4d71bf678bf86d7fd81e57f94ecc6203d5c00ab10331e95b7642d5f114606e4a99ba7c1946e18b3726e974a0c8f8f1cb'))
 	assert.throws(() => assertSevSnpBaseAllowed('snp-base:' + 'ad'.repeat(32)), /base hash/)
 })


### PR DESCRIPTION
## Summary
- replace the undeployed AWS SNP base that lacked the modular ENA driver
- pin the corrected measured base used by reclaim-tee 43de013
- update the allowlist regression

## Verification
- npm run run:test-files -- src/server/utils/sev-snp/verify.test.ts (11/11 pass)

The old base never reached a working deployment, so this is a replacement rather than an additional accepted generation.