### PR TITLE
[FIX] parse EFI X509 signature GUID

### DIFF
--- a/src/server/utils/sev-snp/secure-boot.test.ts
+++ b/src/server/utils/sev-snp/secure-boot.test.ts
@@ -32,7 +32,9 @@ function variable(name: string, value: Buffer): Buffer {
 }
 
 function x509SignatureList(cert: Buffer): Buffer {
-	const x509Guid = Buffer.from('a159c0a594e4a74a87b5ab155c2bf072', 'hex')
+	// EFI_CERT_X509_GUID a5c059a1-94e4-4aa7-87b5-ab155c2bf072,
+	// with the first three GUID fields encoded little-endian on disk.
+	const x509Guid = Buffer.from('a159c0a5e494a74a87b5ab155c2bf072', 'hex')
 	const signatureSize = 16 + cert.length
 	return Buffer.concat([
 		x509Guid,

--- a/src/server/utils/sev-snp/secure-boot.ts
+++ b/src/server/utils/sev-snp/secure-boot.ts
@@ -17,7 +17,7 @@ const TPM_ALG_SHA256 = 0x000b
 const TPM_ALG_SHA384 = 0x000c
 
 // EFI GUIDs use little-endian encoding for the first three fields.
-const EFI_CERT_X509_GUID = 'a159c0a594e4a74a87b5ab155c2bf072'
+const EFI_CERT_X509_GUID = 'a159c0a5e494a74a87b5ab155c2bf072'
 const EFI_CERT_SHA256_GUID = '2616c4c14c509240aca941f936934328'
 
 const RELEASE_SPKI = Buffer.from(createPublicKey(


### PR DESCRIPTION
## Summary

- fix the `EFI_CERT_X509_GUID` byte order used by Secure Boot event-log verification
- correct the synthetic EFI signature-list fixture to match the UEFI on-disk encoding

This fixes the production rejection `unsupported EFI signature type a159c0a5e494a74a87b5ab155c2bf072`.

## Verification

- focused Secure Boot tests: 4 passed
- changed-file ESLint: passed
- captured production proof bundle: both K/T Secure Boot attestations and TEE signatures verified
- full suite: 151 passed, 2 skipped; 2 unrelated environment/timing failures (`ENOTFOUND` timeout expectation and socket-close race)
