### PR TITLE
feat(tee): verify TLS 1.2 CBC bundles

### DIFF
--- a/proto/tee-bundle.proto
+++ b/proto/tee-bundle.proto
@@ -17,6 +17,20 @@ message ResponseRedactionRange {
   int32 length = 2;
 }
 
+enum TLS12CBCRecordMode {
+  TLS12_CBC_RECORD_MODE_UNSPECIFIED = 0;
+  TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT = 1;
+  TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC = 2;
+}
+
+message TLS12CBCSessionBinding {
+  uint32 contract_version = 1;
+  uint32 cipher_suite = 2;
+  TLS12CBCRecordMode record_mode = 3;
+  bool extended_master_secret = 4;
+  bytes session_binding = 5;
+}
+
 message SignedRedactedDecryptionStream {
   bytes redacted_stream = 1;
   uint64 seq_num = 2;
@@ -63,6 +77,7 @@ message KOutputPayload {
   string session_id = 7; // Shared session ID for cross-TEE binding
   repeated OPRFOutput oprf_outputs = 10;  // MPC OPRF outputs (TEE-to-TEE computation) - field 10 to match reclaim-tee
   string attestation_type = 11; // Signed TEE attestation generation
+  TLS12CBCKOutput tls12_cbc = 12;
 }
 
 message TOutputPayload {
@@ -74,6 +89,22 @@ message TOutputPayload {
 
   repeated OPRFOutput oprf_outputs = 10;  // MPC OPRF outputs (TEE-to-TEE computation) - field 10 to match reclaim-tee
   string attestation_type = 11; // Signed TEE attestation generation
+  TLS12CBCTOutput tls12_cbc = 12;
+}
+
+message TLS12CBCKOutput {
+  TLS12CBCSessionBinding binding = 1;
+  bytes authenticated_redacted_request = 2;
+  bytes request_records_sha256 = 3;
+  repeated RequestRedactionRange request_redaction_ranges = 4;
+}
+
+message TLS12CBCTOutput {
+  TLS12CBCSessionBinding binding = 1;
+  bytes authenticated_redacted_response = 2;
+  bytes response_records_sha256 = 3;
+  repeated ResponseRedactionRange response_redaction_ranges = 4;
+  repeated uint32 plaintext_record_lengths = 5;
 }
 
 // Attestation report with structured data

--- a/proto/tee-bundle.proto
+++ b/proto/tee-bundle.proto
@@ -105,6 +105,7 @@ message TLS12CBCTOutput {
   bytes response_records_sha256 = 3;
   repeated ResponseRedactionRange response_redaction_ranges = 4;
   repeated uint32 plaintext_record_lengths = 5;
+  bool close_notify = 6;
 }
 
 // Attestation report with structured data

--- a/src/proto/tee-bundle.ts
+++ b/src/proto/tee-bundle.ts
@@ -9,6 +9,54 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 
 export const protobufPackage = "teeproto";
 
+export const TLS12CBCRecordMode = {
+  TLS12_CBC_RECORD_MODE_UNSPECIFIED: 0,
+  TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT: 1,
+  TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC: 2,
+  UNRECOGNIZED: -1,
+} as const;
+
+export type TLS12CBCRecordMode = typeof TLS12CBCRecordMode[keyof typeof TLS12CBCRecordMode];
+
+export namespace TLS12CBCRecordMode {
+  export type TLS12_CBC_RECORD_MODE_UNSPECIFIED = typeof TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_UNSPECIFIED;
+  export type TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT = typeof TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT;
+  export type TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC = typeof TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC;
+  export type UNRECOGNIZED = typeof TLS12CBCRecordMode.UNRECOGNIZED;
+}
+
+export function tLS12CBCRecordModeFromJSON(object: any): TLS12CBCRecordMode {
+  switch (object) {
+    case 0:
+    case "TLS12_CBC_RECORD_MODE_UNSPECIFIED":
+      return TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_UNSPECIFIED;
+    case 1:
+    case "TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT":
+      return TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT;
+    case 2:
+    case "TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC":
+      return TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return TLS12CBCRecordMode.UNRECOGNIZED;
+  }
+}
+
+export function tLS12CBCRecordModeToJSON(object: TLS12CBCRecordMode): string {
+  switch (object) {
+    case TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_UNSPECIFIED:
+      return "TLS12_CBC_RECORD_MODE_UNSPECIFIED";
+    case TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT:
+      return "TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT";
+    case TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC:
+      return "TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC";
+    case TLS12CBCRecordMode.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
 /** Signature wrapper used everywhere */
 export const BodyType = {
   BODY_TYPE_UNSPECIFIED: 0,
@@ -71,6 +119,14 @@ export interface ResponseRedactionRange {
   length: number;
 }
 
+export interface TLS12CBCSessionBinding {
+  contractVersion: number;
+  cipherSuite: number;
+  recordMode: TLS12CBCRecordMode;
+  extendedMasterSecret: boolean;
+  sessionBinding: Uint8Array;
+}
+
 export interface SignedRedactedDecryptionStream {
   redactedStream: Uint8Array;
   seqNum: number;
@@ -130,6 +186,7 @@ export interface KOutputPayload {
   oprfOutputs: OPRFOutput[];
   /** Signed TEE attestation generation */
   attestationType: string;
+  tls12Cbc: TLS12CBCKOutput | undefined;
 }
 
 export interface TOutputPayload {
@@ -145,6 +202,22 @@ export interface TOutputPayload {
   oprfOutputs: OPRFOutput[];
   /** Signed TEE attestation generation */
   attestationType: string;
+  tls12Cbc: TLS12CBCTOutput | undefined;
+}
+
+export interface TLS12CBCKOutput {
+  binding: TLS12CBCSessionBinding | undefined;
+  authenticatedRedactedRequest: Uint8Array;
+  requestRecordsSha256: Uint8Array;
+  requestRedactionRanges: RequestRedactionRange[];
+}
+
+export interface TLS12CBCTOutput {
+  binding: TLS12CBCSessionBinding | undefined;
+  authenticatedRedactedResponse: Uint8Array;
+  responseRecordsSha256: Uint8Array;
+  responseRedactionRanges: ResponseRedactionRange[];
+  plaintextRecordLengths: number[];
 }
 
 /** Attestation report with structured data */
@@ -355,6 +428,156 @@ export const ResponseRedactionRange: MessageFns<ResponseRedactionRange> = {
     const message = createBaseResponseRedactionRange();
     message.start = object.start ?? 0;
     message.length = object.length ?? 0;
+    return message;
+  },
+};
+
+function createBaseTLS12CBCSessionBinding(): TLS12CBCSessionBinding {
+  return {
+    contractVersion: 0,
+    cipherSuite: 0,
+    recordMode: 0,
+    extendedMasterSecret: false,
+    sessionBinding: new Uint8Array(0),
+  };
+}
+
+export const TLS12CBCSessionBinding: MessageFns<TLS12CBCSessionBinding> = {
+  encode(message: TLS12CBCSessionBinding, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.contractVersion !== 0) {
+      writer.uint32(8).uint32(message.contractVersion);
+    }
+    if (message.cipherSuite !== 0) {
+      writer.uint32(16).uint32(message.cipherSuite);
+    }
+    if (message.recordMode !== 0) {
+      writer.uint32(24).int32(message.recordMode);
+    }
+    if (message.extendedMasterSecret !== false) {
+      writer.uint32(32).bool(message.extendedMasterSecret);
+    }
+    if (message.sessionBinding.length !== 0) {
+      writer.uint32(42).bytes(message.sessionBinding);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TLS12CBCSessionBinding {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTLS12CBCSessionBinding();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.contractVersion = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.cipherSuite = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.recordMode = reader.int32() as any;
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.extendedMasterSecret = reader.bool();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.sessionBinding = reader.bytes();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TLS12CBCSessionBinding {
+    return {
+      contractVersion: isSet(object.contractVersion)
+        ? globalThis.Number(object.contractVersion)
+        : isSet(object.contract_version)
+        ? globalThis.Number(object.contract_version)
+        : 0,
+      cipherSuite: isSet(object.cipherSuite)
+        ? globalThis.Number(object.cipherSuite)
+        : isSet(object.cipher_suite)
+        ? globalThis.Number(object.cipher_suite)
+        : 0,
+      recordMode: isSet(object.recordMode)
+        ? tLS12CBCRecordModeFromJSON(object.recordMode)
+        : isSet(object.record_mode)
+        ? tLS12CBCRecordModeFromJSON(object.record_mode)
+        : 0,
+      extendedMasterSecret: isSet(object.extendedMasterSecret)
+        ? globalThis.Boolean(object.extendedMasterSecret)
+        : isSet(object.extended_master_secret)
+        ? globalThis.Boolean(object.extended_master_secret)
+        : false,
+      sessionBinding: isSet(object.sessionBinding)
+        ? bytesFromBase64(object.sessionBinding)
+        : isSet(object.session_binding)
+        ? bytesFromBase64(object.session_binding)
+        : new Uint8Array(0),
+    };
+  },
+
+  toJSON(message: TLS12CBCSessionBinding): unknown {
+    const obj: any = {};
+    if (message.contractVersion !== 0) {
+      obj.contractVersion = Math.round(message.contractVersion);
+    }
+    if (message.cipherSuite !== 0) {
+      obj.cipherSuite = Math.round(message.cipherSuite);
+    }
+    if (message.recordMode !== 0) {
+      obj.recordMode = tLS12CBCRecordModeToJSON(message.recordMode);
+    }
+    if (message.extendedMasterSecret !== false) {
+      obj.extendedMasterSecret = message.extendedMasterSecret;
+    }
+    if (message.sessionBinding.length !== 0) {
+      obj.sessionBinding = base64FromBytes(message.sessionBinding);
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<TLS12CBCSessionBinding>): TLS12CBCSessionBinding {
+    return TLS12CBCSessionBinding.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<TLS12CBCSessionBinding>): TLS12CBCSessionBinding {
+    const message = createBaseTLS12CBCSessionBinding();
+    message.contractVersion = object.contractVersion ?? 0;
+    message.cipherSuite = object.cipherSuite ?? 0;
+    message.recordMode = object.recordMode ?? 0;
+    message.extendedMasterSecret = object.extendedMasterSecret ?? false;
+    message.sessionBinding = object.sessionBinding ?? new Uint8Array(0);
     return message;
   },
 };
@@ -886,6 +1109,7 @@ function createBaseKOutputPayload(): KOutputPayload {
     sessionId: "",
     oprfOutputs: [],
     attestationType: "",
+    tls12Cbc: undefined,
   };
 }
 
@@ -917,6 +1141,9 @@ export const KOutputPayload: MessageFns<KOutputPayload> = {
     }
     if (message.attestationType !== "") {
       writer.uint32(90).string(message.attestationType);
+    }
+    if (message.tls12Cbc !== undefined) {
+      TLS12CBCKOutput.encode(message.tls12Cbc, writer.uint32(98).fork()).join();
     }
     return writer;
   },
@@ -1000,6 +1227,14 @@ export const KOutputPayload: MessageFns<KOutputPayload> = {
           message.attestationType = reader.string();
           continue;
         }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.tls12Cbc = TLS12CBCKOutput.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1056,6 +1291,11 @@ export const KOutputPayload: MessageFns<KOutputPayload> = {
         : isSet(object.attestation_type)
         ? globalThis.String(object.attestation_type)
         : "",
+      tls12Cbc: isSet(object.tls12Cbc)
+        ? TLS12CBCKOutput.fromJSON(object.tls12Cbc)
+        : isSet(object.tls12_cbc)
+        ? TLS12CBCKOutput.fromJSON(object.tls12_cbc)
+        : undefined,
     };
   },
 
@@ -1088,6 +1328,9 @@ export const KOutputPayload: MessageFns<KOutputPayload> = {
     if (message.attestationType !== "") {
       obj.attestationType = message.attestationType;
     }
+    if (message.tls12Cbc !== undefined) {
+      obj.tls12Cbc = TLS12CBCKOutput.toJSON(message.tls12Cbc);
+    }
     return obj;
   },
 
@@ -1109,6 +1352,9 @@ export const KOutputPayload: MessageFns<KOutputPayload> = {
     message.sessionId = object.sessionId ?? "";
     message.oprfOutputs = object.oprfOutputs?.map((e) => OPRFOutput.fromPartial(e)) || [];
     message.attestationType = object.attestationType ?? "";
+    message.tls12Cbc = (object.tls12Cbc !== undefined && object.tls12Cbc !== null)
+      ? TLS12CBCKOutput.fromPartial(object.tls12Cbc)
+      : undefined;
     return message;
   },
 };
@@ -1121,6 +1367,7 @@ function createBaseTOutputPayload(): TOutputPayload {
     sessionId: "",
     oprfOutputs: [],
     attestationType: "",
+    tls12Cbc: undefined,
   };
 }
 
@@ -1143,6 +1390,9 @@ export const TOutputPayload: MessageFns<TOutputPayload> = {
     }
     if (message.attestationType !== "") {
       writer.uint32(90).string(message.attestationType);
+    }
+    if (message.tls12Cbc !== undefined) {
+      TLS12CBCTOutput.encode(message.tls12Cbc, writer.uint32(98).fork()).join();
     }
     return writer;
   },
@@ -1202,6 +1452,14 @@ export const TOutputPayload: MessageFns<TOutputPayload> = {
           message.attestationType = reader.string();
           continue;
         }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.tls12Cbc = TLS12CBCTOutput.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1243,6 +1501,11 @@ export const TOutputPayload: MessageFns<TOutputPayload> = {
         : isSet(object.attestation_type)
         ? globalThis.String(object.attestation_type)
         : "",
+      tls12Cbc: isSet(object.tls12Cbc)
+        ? TLS12CBCTOutput.fromJSON(object.tls12Cbc)
+        : isSet(object.tls12_cbc)
+        ? TLS12CBCTOutput.fromJSON(object.tls12_cbc)
+        : undefined,
     };
   },
 
@@ -1266,6 +1529,9 @@ export const TOutputPayload: MessageFns<TOutputPayload> = {
     if (message.attestationType !== "") {
       obj.attestationType = message.attestationType;
     }
+    if (message.tls12Cbc !== undefined) {
+      obj.tls12Cbc = TLS12CBCTOutput.toJSON(message.tls12Cbc);
+    }
     return obj;
   },
 
@@ -1280,6 +1546,298 @@ export const TOutputPayload: MessageFns<TOutputPayload> = {
     message.sessionId = object.sessionId ?? "";
     message.oprfOutputs = object.oprfOutputs?.map((e) => OPRFOutput.fromPartial(e)) || [];
     message.attestationType = object.attestationType ?? "";
+    message.tls12Cbc = (object.tls12Cbc !== undefined && object.tls12Cbc !== null)
+      ? TLS12CBCTOutput.fromPartial(object.tls12Cbc)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseTLS12CBCKOutput(): TLS12CBCKOutput {
+  return {
+    binding: undefined,
+    authenticatedRedactedRequest: new Uint8Array(0),
+    requestRecordsSha256: new Uint8Array(0),
+    requestRedactionRanges: [],
+  };
+}
+
+export const TLS12CBCKOutput: MessageFns<TLS12CBCKOutput> = {
+  encode(message: TLS12CBCKOutput, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.binding !== undefined) {
+      TLS12CBCSessionBinding.encode(message.binding, writer.uint32(10).fork()).join();
+    }
+    if (message.authenticatedRedactedRequest.length !== 0) {
+      writer.uint32(18).bytes(message.authenticatedRedactedRequest);
+    }
+    if (message.requestRecordsSha256.length !== 0) {
+      writer.uint32(26).bytes(message.requestRecordsSha256);
+    }
+    for (const v of message.requestRedactionRanges) {
+      RequestRedactionRange.encode(v!, writer.uint32(34).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TLS12CBCKOutput {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTLS12CBCKOutput();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.binding = TLS12CBCSessionBinding.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.authenticatedRedactedRequest = reader.bytes();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.requestRecordsSha256 = reader.bytes();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.requestRedactionRanges.push(RequestRedactionRange.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TLS12CBCKOutput {
+    return {
+      binding: isSet(object.binding) ? TLS12CBCSessionBinding.fromJSON(object.binding) : undefined,
+      authenticatedRedactedRequest: isSet(object.authenticatedRedactedRequest)
+        ? bytesFromBase64(object.authenticatedRedactedRequest)
+        : isSet(object.authenticated_redacted_request)
+        ? bytesFromBase64(object.authenticated_redacted_request)
+        : new Uint8Array(0),
+      requestRecordsSha256: isSet(object.requestRecordsSha256)
+        ? bytesFromBase64(object.requestRecordsSha256)
+        : isSet(object.request_records_sha256)
+        ? bytesFromBase64(object.request_records_sha256)
+        : new Uint8Array(0),
+      requestRedactionRanges: globalThis.Array.isArray(object?.requestRedactionRanges)
+        ? object.requestRedactionRanges.map((e: any) => RequestRedactionRange.fromJSON(e))
+        : globalThis.Array.isArray(object?.request_redaction_ranges)
+        ? object.request_redaction_ranges.map((e: any) => RequestRedactionRange.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: TLS12CBCKOutput): unknown {
+    const obj: any = {};
+    if (message.binding !== undefined) {
+      obj.binding = TLS12CBCSessionBinding.toJSON(message.binding);
+    }
+    if (message.authenticatedRedactedRequest.length !== 0) {
+      obj.authenticatedRedactedRequest = base64FromBytes(message.authenticatedRedactedRequest);
+    }
+    if (message.requestRecordsSha256.length !== 0) {
+      obj.requestRecordsSha256 = base64FromBytes(message.requestRecordsSha256);
+    }
+    if (message.requestRedactionRanges?.length) {
+      obj.requestRedactionRanges = message.requestRedactionRanges.map((e) => RequestRedactionRange.toJSON(e));
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<TLS12CBCKOutput>): TLS12CBCKOutput {
+    return TLS12CBCKOutput.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<TLS12CBCKOutput>): TLS12CBCKOutput {
+    const message = createBaseTLS12CBCKOutput();
+    message.binding = (object.binding !== undefined && object.binding !== null)
+      ? TLS12CBCSessionBinding.fromPartial(object.binding)
+      : undefined;
+    message.authenticatedRedactedRequest = object.authenticatedRedactedRequest ?? new Uint8Array(0);
+    message.requestRecordsSha256 = object.requestRecordsSha256 ?? new Uint8Array(0);
+    message.requestRedactionRanges = object.requestRedactionRanges?.map((e) => RequestRedactionRange.fromPartial(e)) ||
+      [];
+    return message;
+  },
+};
+
+function createBaseTLS12CBCTOutput(): TLS12CBCTOutput {
+  return {
+    binding: undefined,
+    authenticatedRedactedResponse: new Uint8Array(0),
+    responseRecordsSha256: new Uint8Array(0),
+    responseRedactionRanges: [],
+    plaintextRecordLengths: [],
+  };
+}
+
+export const TLS12CBCTOutput: MessageFns<TLS12CBCTOutput> = {
+  encode(message: TLS12CBCTOutput, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.binding !== undefined) {
+      TLS12CBCSessionBinding.encode(message.binding, writer.uint32(10).fork()).join();
+    }
+    if (message.authenticatedRedactedResponse.length !== 0) {
+      writer.uint32(18).bytes(message.authenticatedRedactedResponse);
+    }
+    if (message.responseRecordsSha256.length !== 0) {
+      writer.uint32(26).bytes(message.responseRecordsSha256);
+    }
+    for (const v of message.responseRedactionRanges) {
+      ResponseRedactionRange.encode(v!, writer.uint32(34).fork()).join();
+    }
+    writer.uint32(42).fork();
+    for (const v of message.plaintextRecordLengths) {
+      writer.uint32(v);
+    }
+    writer.join();
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TLS12CBCTOutput {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTLS12CBCTOutput();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.binding = TLS12CBCSessionBinding.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.authenticatedRedactedResponse = reader.bytes();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.responseRecordsSha256 = reader.bytes();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.responseRedactionRanges.push(ResponseRedactionRange.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 5: {
+          if (tag === 40) {
+            message.plaintextRecordLengths.push(reader.uint32());
+
+            continue;
+          }
+
+          if (tag === 42) {
+            const end2 = reader.uint32() + reader.pos;
+            while (reader.pos < end2) {
+              message.plaintextRecordLengths.push(reader.uint32());
+            }
+
+            continue;
+          }
+
+          break;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TLS12CBCTOutput {
+    return {
+      binding: isSet(object.binding) ? TLS12CBCSessionBinding.fromJSON(object.binding) : undefined,
+      authenticatedRedactedResponse: isSet(object.authenticatedRedactedResponse)
+        ? bytesFromBase64(object.authenticatedRedactedResponse)
+        : isSet(object.authenticated_redacted_response)
+        ? bytesFromBase64(object.authenticated_redacted_response)
+        : new Uint8Array(0),
+      responseRecordsSha256: isSet(object.responseRecordsSha256)
+        ? bytesFromBase64(object.responseRecordsSha256)
+        : isSet(object.response_records_sha256)
+        ? bytesFromBase64(object.response_records_sha256)
+        : new Uint8Array(0),
+      responseRedactionRanges: globalThis.Array.isArray(object?.responseRedactionRanges)
+        ? object.responseRedactionRanges.map((e: any) => ResponseRedactionRange.fromJSON(e))
+        : globalThis.Array.isArray(object?.response_redaction_ranges)
+        ? object.response_redaction_ranges.map((e: any) => ResponseRedactionRange.fromJSON(e))
+        : [],
+      plaintextRecordLengths: globalThis.Array.isArray(object?.plaintextRecordLengths)
+        ? object.plaintextRecordLengths.map((e: any) => globalThis.Number(e))
+        : globalThis.Array.isArray(object?.plaintext_record_lengths)
+        ? object.plaintext_record_lengths.map((e: any) => globalThis.Number(e))
+        : [],
+    };
+  },
+
+  toJSON(message: TLS12CBCTOutput): unknown {
+    const obj: any = {};
+    if (message.binding !== undefined) {
+      obj.binding = TLS12CBCSessionBinding.toJSON(message.binding);
+    }
+    if (message.authenticatedRedactedResponse.length !== 0) {
+      obj.authenticatedRedactedResponse = base64FromBytes(message.authenticatedRedactedResponse);
+    }
+    if (message.responseRecordsSha256.length !== 0) {
+      obj.responseRecordsSha256 = base64FromBytes(message.responseRecordsSha256);
+    }
+    if (message.responseRedactionRanges?.length) {
+      obj.responseRedactionRanges = message.responseRedactionRanges.map((e) => ResponseRedactionRange.toJSON(e));
+    }
+    if (message.plaintextRecordLengths?.length) {
+      obj.plaintextRecordLengths = message.plaintextRecordLengths.map((e) => Math.round(e));
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<TLS12CBCTOutput>): TLS12CBCTOutput {
+    return TLS12CBCTOutput.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<TLS12CBCTOutput>): TLS12CBCTOutput {
+    const message = createBaseTLS12CBCTOutput();
+    message.binding = (object.binding !== undefined && object.binding !== null)
+      ? TLS12CBCSessionBinding.fromPartial(object.binding)
+      : undefined;
+    message.authenticatedRedactedResponse = object.authenticatedRedactedResponse ?? new Uint8Array(0);
+    message.responseRecordsSha256 = object.responseRecordsSha256 ?? new Uint8Array(0);
+    message.responseRedactionRanges =
+      object.responseRedactionRanges?.map((e) => ResponseRedactionRange.fromPartial(e)) || [];
+    message.plaintextRecordLengths = object.plaintextRecordLengths?.map((e) => e) || [];
     return message;
   },
 };

--- a/src/proto/tee-bundle.ts
+++ b/src/proto/tee-bundle.ts
@@ -218,6 +218,7 @@ export interface TLS12CBCTOutput {
   responseRecordsSha256: Uint8Array;
   responseRedactionRanges: ResponseRedactionRange[];
   plaintextRecordLengths: number[];
+  closeNotify: boolean;
 }
 
 /** Attestation report with structured data */
@@ -1688,6 +1689,7 @@ function createBaseTLS12CBCTOutput(): TLS12CBCTOutput {
     responseRecordsSha256: new Uint8Array(0),
     responseRedactionRanges: [],
     plaintextRecordLengths: [],
+    closeNotify: false,
   };
 }
 
@@ -1710,6 +1712,9 @@ export const TLS12CBCTOutput: MessageFns<TLS12CBCTOutput> = {
       writer.uint32(v);
     }
     writer.join();
+    if (message.closeNotify !== false) {
+      writer.uint32(48).bool(message.closeNotify);
+    }
     return writer;
   },
 
@@ -1770,6 +1775,14 @@ export const TLS12CBCTOutput: MessageFns<TLS12CBCTOutput> = {
 
           break;
         }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.closeNotify = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1802,6 +1815,11 @@ export const TLS12CBCTOutput: MessageFns<TLS12CBCTOutput> = {
         : globalThis.Array.isArray(object?.plaintext_record_lengths)
         ? object.plaintext_record_lengths.map((e: any) => globalThis.Number(e))
         : [],
+      closeNotify: isSet(object.closeNotify)
+        ? globalThis.Boolean(object.closeNotify)
+        : isSet(object.close_notify)
+        ? globalThis.Boolean(object.close_notify)
+        : false,
     };
   },
 
@@ -1822,6 +1840,9 @@ export const TLS12CBCTOutput: MessageFns<TLS12CBCTOutput> = {
     if (message.plaintextRecordLengths?.length) {
       obj.plaintextRecordLengths = message.plaintextRecordLengths.map((e) => Math.round(e));
     }
+    if (message.closeNotify !== false) {
+      obj.closeNotify = message.closeNotify;
+    }
     return obj;
   },
 
@@ -1838,6 +1859,7 @@ export const TLS12CBCTOutput: MessageFns<TLS12CBCTOutput> = {
     message.responseRedactionRanges =
       object.responseRedactionRanges?.map((e) => ResponseRedactionRange.fromPartial(e)) || [];
     message.plaintextRecordLengths = object.plaintextRecordLengths?.map((e) => e) || [];
+    message.closeNotify = object.closeNotify ?? false;
     return message;
   },
 };

--- a/src/server/handlers/claimTeeBundle.ts
+++ b/src/server/handlers/claimTeeBundle.ts
@@ -328,7 +328,7 @@ function validateTlsCertificate(
  * Validates OPRF results have no overlapping ranges and combines them
  * SECURITY: Prevents position collisions between ZK and OPRF MPC results
  */
-export function validateAndCombineOprfResults(
+function validateAndCombineOprfResults(
 	zkOprfResults: OprfVerificationResult[],
 	oprfMpcResults: OprfVerificationResult[],
 	logger: Logger
@@ -341,20 +341,41 @@ export function validateAndCombineOprfResults(
 
 	logger.info(`Combined ${zkOprfResults.length} ZK OPRF + ${oprfMpcResults.length} OPRF MPC results`)
 
-	const sorted = allOprfResults
-		.map((result, index) => ({ result, source: index < zkOprfResults.length ? 'zk' : 'mpc' }))
-		.sort((a, b) => a.result.position - b.result.position)
-	for(let i = 1; i < sorted.length; i++) {
-		const previous = sorted[i - 1]
-		const current = sorted[i]
-		const previousEnd = previous.result.position + previous.result.length
-		if(current.result.position < previousEnd) {
-			throw new AttestorError(
-				'ERROR_INVALID_CLAIM',
-				`Overlapping OPRF ranges: [${previous.result.position}:${previousEnd}] (${previous.source}) and ` +
-				`[${current.result.position}:${current.result.position + current.result.length}] (${current.source})`
-			)
+	// Preserve the split-AEAD behavior: exact ZK/MPC duplicates are accepted,
+	// while partial overlaps are rejected. CBC forbids ZK OPRF data and checks
+	// overlap among its MPC ranges before this function is called.
+	const seen: Record<number, { length: number, source: string }> = {}
+	for(const result of zkOprfResults) {
+		seen[result.position] = { length: result.length, source: 'zk' }
+	}
+
+	for(const result of oprfMpcResults) {
+		const existing = seen[result.position]
+		if(existing) {
+			if(existing.length !== result.length) {
+				throw new AttestorError(
+					'ERROR_INVALID_CLAIM',
+					`OPRF range conflict at position ${result.position}: ZK length ${existing.length} vs MPC length ${result.length}`
+				)
+			}
+
+			logger.warn(`Duplicate OPRF range at position ${result.position} from both ZK and MPC - using MPC result`)
 		}
+
+		for(const [pos, data] of Object.entries(seen)) {
+			const position = Number(pos)
+			const existingEnd = position + data.length
+			const newEnd = result.position + result.length
+			const overlaps = (result.position < existingEnd && newEnd > position) && result.position !== position
+			if(overlaps) {
+				throw new AttestorError(
+					'ERROR_INVALID_CLAIM',
+					`Overlapping OPRF ranges: [${position}:${existingEnd}] (${data.source}) and [${result.position}:${newEnd}] (mpc)`
+				)
+			}
+		}
+
+		seen[result.position] = { length: result.length, source: 'mpc' }
 	}
 
 	return allOprfResults

--- a/src/server/handlers/claimTeeBundle.ts
+++ b/src/server/handlers/claimTeeBundle.ts
@@ -328,7 +328,7 @@ function validateTlsCertificate(
  * Validates OPRF results have no overlapping ranges and combines them
  * SECURITY: Prevents position collisions between ZK and OPRF MPC results
  */
-function validateAndCombineOprfResults(
+export function validateAndCombineOprfResults(
 	zkOprfResults: OprfVerificationResult[],
 	oprfMpcResults: OprfVerificationResult[],
 	logger: Logger
@@ -341,41 +341,20 @@ function validateAndCombineOprfResults(
 
 	logger.info(`Combined ${zkOprfResults.length} ZK OPRF + ${oprfMpcResults.length} OPRF MPC results`)
 
-	// Check for overlapping ranges (position collision detection)
-	const seen: Record<number, { length: number, source: string }> = {}
-	for(const result of zkOprfResults) {
-		seen[result.position] = { length: result.length, source: 'zk' }
-	}
-
-	for(const result of oprfMpcResults) {
-		const existing = seen[result.position]
-		if(existing) {
-			// Exact duplicate at same position - verify they match
-			if(existing.length !== result.length) {
-				throw new AttestorError(
-					'ERROR_INVALID_CLAIM',
-					`OPRF range conflict at position ${result.position}: ZK length ${existing.length} vs MPC length ${result.length}`
-				)
-			}
-
-			logger.warn(`Duplicate OPRF range at position ${result.position} from both ZK and MPC - using MPC result`)
+	const sorted = allOprfResults
+		.map((result, index) => ({ result, source: index < zkOprfResults.length ? 'zk' : 'mpc' }))
+		.sort((a, b) => a.result.position - b.result.position)
+	for(let i = 1; i < sorted.length; i++) {
+		const previous = sorted[i - 1]
+		const current = sorted[i]
+		const previousEnd = previous.result.position + previous.result.length
+		if(current.result.position < previousEnd) {
+			throw new AttestorError(
+				'ERROR_INVALID_CLAIM',
+				`Overlapping OPRF ranges: [${previous.result.position}:${previousEnd}] (${previous.source}) and ` +
+				`[${current.result.position}:${current.result.position + current.result.length}] (${current.source})`
+			)
 		}
-
-		// Check for overlapping (but not identical) ranges
-		for(const [pos, data] of Object.entries(seen)) {
-			const position = Number(pos)
-			const existingEnd = position + data.length
-			const newEnd = result.position + result.length
-			const overlaps = (result.position < existingEnd && newEnd > position) && result.position !== position
-			if(overlaps) {
-				throw new AttestorError(
-					'ERROR_INVALID_CLAIM',
-					`Overlapping OPRF ranges: [${position}:${existingEnd}] (${data.source}) and [${result.position}:${newEnd}] (mpc)`
-				)
-			}
-		}
-
-		seen[result.position] = { length: result.length, source: 'mpc' }
 	}
 
 	return allOprfResults

--- a/src/server/utils/tee-cbc-contract.ts
+++ b/src/server/utils/tee-cbc-contract.ts
@@ -1,0 +1,231 @@
+import type {
+	KOutputPayload,
+	RequestRedactionRange,
+	ResponseRedactionRange,
+	TLS12CBCSessionBinding,
+	TOutputPayload,
+	VerificationBundle,
+} from '#src/proto/tee-bundle.ts'
+import { TLS12CBCRecordMode } from '#src/proto/tee-bundle.ts'
+import { AttestorError } from '#src/utils/error.ts'
+
+export type TeeProtocolMode = 'split-aead' | 'tls12-cbc'
+
+const TLS12_CBC_CONTRACT_VERSION = 1
+const TLS12_CBC_BINDING_SIZE = 32
+const TLS12_CBC_DIGEST_SIZE = 32
+const TLS12_MAX_PLAINTEXT = 16_384
+const TLS12_MAX_RECORDS = 500
+const MAX_HTTP_REQUEST_SIZE = 1 << 20
+const MAX_REQUEST_REDACTIONS = 1_000
+const MAX_RESPONSE_REDACTIONS = 1_000
+
+const TLS12_CBC_CIPHER_SUITES = new Set([
+	0xc009,
+	0xc013,
+	0xc00a,
+	0xc014,
+	0xc023,
+	0xc027,
+	0xc024,
+	0xc028,
+	0x002f,
+	0x0035,
+	0x003c,
+	0x003d,
+])
+
+export function validateTeeTranscriptContract(
+	bundle: VerificationBundle,
+	kPayload: KOutputPayload,
+	tPayload: TOutputPayload,
+): TeeProtocolMode {
+	const hasKContract = kPayload.tls12Cbc !== undefined
+	const hasTContract = tPayload.tls12Cbc !== undefined
+
+	if(hasKContract !== hasTContract) {
+		throw invalidClaim('TLS 1.2 CBC contract must be present in both TEE payloads')
+	}
+
+	if(!hasKContract || !hasTContract) {
+		validateLegacyContract(kPayload, tPayload)
+		return 'split-aead'
+	}
+
+	validateTls12CbcContract(bundle, kPayload, tPayload)
+	return 'tls12-cbc'
+}
+
+function validateLegacyContract(kPayload: KOutputPayload, tPayload: TOutputPayload): void {
+	if(kPayload.consolidatedResponseKeystream.length === 0) {
+		throw invalidClaim('Missing consolidated response keystream in TEE_K payload')
+	}
+
+	if(tPayload.consolidatedResponseCiphertext.length === 0) {
+		throw invalidClaim('Missing consolidated response ciphertext in TEE_T payload')
+	}
+}
+
+function validateTls12CbcContract(
+	bundle: VerificationBundle,
+	kPayload: KOutputPayload,
+	tPayload: TOutputPayload,
+): void {
+	const kContract = kPayload.tls12Cbc!
+	const tContract = tPayload.tls12Cbc!
+
+	if(kPayload.redactedRequest.length !== 0 || kPayload.requestRedactionRanges.length !== 0 ||
+		kPayload.consolidatedResponseKeystream.length !== 0 || kPayload.responseRedactionRanges.length !== 0) {
+		throw invalidClaim('TEE_K TLS 1.2 CBC output mixes legacy split-AEAD fields')
+	}
+
+	if(tPayload.consolidatedResponseCiphertext.length !== 0 || tPayload.requestProofStreams.length !== 0) {
+		throw invalidClaim('TEE_T TLS 1.2 CBC output mixes legacy split-AEAD fields')
+	}
+
+	if(bundle.oprfVerifications.length !== 0) {
+		throw invalidClaim('TLS 1.2 CBC does not support legacy ZK TOPRF verification data')
+	}
+
+	validateBinding(kContract.binding, 'TEE_K')
+	validateBinding(tContract.binding, 'TEE_T')
+	if(!bindingsEqual(kContract.binding!, tContract.binding!)) {
+		throw invalidClaim('TLS 1.2 CBC session binding mismatch between TEE_K and TEE_T')
+	}
+
+	if(kContract.authenticatedRedactedRequest.length === 0 ||
+		kContract.authenticatedRedactedRequest.length > MAX_HTTP_REQUEST_SIZE) {
+		throw invalidClaim('Invalid TLS 1.2 CBC authenticated request length')
+	}
+
+	if(kContract.requestRecordsSha256.length !== TLS12_CBC_DIGEST_SIZE) {
+		throw invalidClaim('TLS 1.2 CBC request record digest must be 32 bytes')
+	}
+
+	validateRequestRanges(kContract.requestRedactionRanges, kContract.authenticatedRedactedRequest.length)
+
+	const responseLength = tContract.authenticatedRedactedResponse.length
+	if(responseLength === 0 || responseLength > TLS12_MAX_RECORDS * TLS12_MAX_PLAINTEXT) {
+		throw invalidClaim('Invalid TLS 1.2 CBC authenticated response length')
+	}
+
+	if(tContract.responseRecordsSha256.length !== TLS12_CBC_DIGEST_SIZE) {
+		throw invalidClaim('TLS 1.2 CBC response record digest must be 32 bytes')
+	}
+
+	validateResponseRanges(tContract.responseRedactionRanges, responseLength)
+	validatePlaintextRecordLengths(tContract.plaintextRecordLengths, responseLength)
+}
+
+function validateBinding(binding: TLS12CBCSessionBinding | undefined, owner: string): void {
+	if(!binding) {
+		throw invalidClaim(`${owner} TLS 1.2 CBC binding is missing`)
+	}
+
+	if(binding.contractVersion !== TLS12_CBC_CONTRACT_VERSION) {
+		throw invalidClaim(`${owner} TLS 1.2 CBC contract version is unsupported`)
+	}
+
+	if(!TLS12_CBC_CIPHER_SUITES.has(binding.cipherSuite)) {
+		throw invalidClaim(`${owner} TLS 1.2 CBC cipher suite is unsupported`)
+	}
+
+	if(binding.recordMode !== TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT &&
+		binding.recordMode !== TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_ENCRYPT_THEN_MAC) {
+		throw invalidClaim(`${owner} TLS 1.2 CBC record mode is invalid`)
+	}
+
+	if(binding.sessionBinding.length !== TLS12_CBC_BINDING_SIZE) {
+		throw invalidClaim(`${owner} TLS 1.2 CBC session binding must be 32 bytes`)
+	}
+}
+
+function bindingsEqual(a: TLS12CBCSessionBinding, b: TLS12CBCSessionBinding): boolean {
+	return a.contractVersion === b.contractVersion &&
+		a.cipherSuite === b.cipherSuite &&
+		a.recordMode === b.recordMode &&
+		a.extendedMasterSecret === b.extendedMasterSecret &&
+		bytesEqual(a.sessionBinding, b.sessionBinding)
+}
+
+function validateRequestRanges(ranges: RequestRedactionRange[], requestLength: number): void {
+	if(ranges.length > MAX_REQUEST_REDACTIONS) {
+		throw invalidClaim('Too many TLS 1.2 CBC request redaction ranges')
+	}
+
+	for(const [index, range] of ranges.entries()) {
+		if(range.start < 0 || range.length <= 0 || range.start > requestLength ||
+			range.length > requestLength - range.start) {
+			throw invalidClaim(`TLS 1.2 CBC request redaction range ${index} is out of bounds`)
+		}
+
+		if(range.type !== 'sensitive' && range.type !== 'sensitive_proof') {
+			throw invalidClaim(`TLS 1.2 CBC request redaction range ${index} has invalid type`)
+		}
+	}
+
+	validateNoOverlap(ranges, 'request')
+}
+
+function validateResponseRanges(ranges: ResponseRedactionRange[], responseLength: number): void {
+	if(ranges.length > MAX_RESPONSE_REDACTIONS) {
+		throw invalidClaim('Too many TLS 1.2 CBC response redaction ranges')
+	}
+
+	for(const [index, range] of ranges.entries()) {
+		if(range.start < 0 || range.length <= 0 || range.start > responseLength ||
+			range.length > responseLength - range.start) {
+			throw invalidClaim(`TLS 1.2 CBC response redaction range ${index} is out of bounds`)
+		}
+	}
+
+	validateNoOverlap(ranges, 'response')
+}
+
+function validateNoOverlap(
+	ranges: Array<{ start: number, length: number }>,
+	direction: 'request' | 'response',
+): void {
+	const sorted = [...ranges].sort((a, b) => a.start - b.start)
+	for(let i = 1; i < sorted.length; i++) {
+		const previous = sorted[i - 1]
+		const current = sorted[i]
+		if(current.start < previous.start + previous.length) {
+			throw invalidClaim(`TLS 1.2 CBC ${direction} redaction ranges overlap`)
+		}
+	}
+}
+
+function validatePlaintextRecordLengths(lengths: number[], responseLength: number): void {
+	if(lengths.length === 0 || lengths.length > TLS12_MAX_RECORDS) {
+		throw invalidClaim('Invalid TLS 1.2 CBC plaintext record count')
+	}
+
+	let total = 0
+	for(const [index, length] of lengths.entries()) {
+		if(length < 0 || length > TLS12_MAX_PLAINTEXT) {
+			throw invalidClaim(`TLS 1.2 CBC plaintext record length ${index} is invalid`)
+		}
+		total += length
+	}
+
+	if(total !== responseLength) {
+		throw invalidClaim('TLS 1.2 CBC plaintext record lengths do not match the authenticated response')
+	}
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if(a.length !== b.length) {
+		return false
+	}
+
+	let difference = 0
+	for(let i = 0; i < a.length; i++) {
+		difference |= a[i] ^ b[i]
+	}
+	return difference === 0
+}
+
+function invalidClaim(message: string): AttestorError {
+	return new AttestorError('ERROR_INVALID_CLAIM', message)
+}

--- a/src/server/utils/tee-cbc-contract.ts
+++ b/src/server/utils/tee-cbc-contract.ts
@@ -16,9 +16,9 @@ const TLS12_CBC_BINDING_SIZE = 32
 const TLS12_CBC_DIGEST_SIZE = 32
 const TLS12_MAX_PLAINTEXT = 16_384
 const TLS12_MAX_RECORDS = 500
-const MAX_HTTP_REQUEST_SIZE = 1 << 20
 const MAX_REQUEST_REDACTIONS = 1_000
 const MAX_RESPONSE_REDACTIONS = 1_000
+const REDACTION_CHAR_CODE = 42
 
 const TLS12_CBC_CIPHER_SUITES = new Set([
 	0xc009,
@@ -94,7 +94,7 @@ function validateTls12CbcContract(
 	}
 
 	if(kContract.authenticatedRedactedRequest.length === 0 ||
-		kContract.authenticatedRedactedRequest.length > MAX_HTTP_REQUEST_SIZE) {
+		kContract.authenticatedRedactedRequest.length > TLS12_MAX_PLAINTEXT) {
 		throw invalidClaim('Invalid TLS 1.2 CBC authenticated request length')
 	}
 
@@ -115,6 +115,193 @@ function validateTls12CbcContract(
 
 	validateResponseRanges(tContract.responseRedactionRanges, responseLength)
 	validatePlaintextRecordLengths(tContract.plaintextRecordLengths, responseLength)
+	validateTls12CbcHttpResponseFraming(
+		tContract.authenticatedRedactedResponse,
+		tContract.responseRedactionRanges,
+		tContract.closeNotify,
+	)
+}
+
+function validateTls12CbcHttpResponseFraming(
+	response: Uint8Array,
+	ranges: ResponseRedactionRange[],
+	closeNotify: boolean,
+): void {
+	const visible = new Uint8Array(response)
+	const redacted = new Uint8Array(response.length)
+	for(const range of ranges) {
+		visible.fill(REDACTION_CHAR_CODE, range.start, range.start + range.length)
+		redacted.fill(1, range.start, range.start + range.length)
+	}
+
+	const headerEnd = findSequence(visible, [13, 10, 13, 10], 0)
+	if(headerEnd < 0) {
+		throw invalidClaim('TLS 1.2 CBC response has incomplete HTTP headers')
+	}
+
+	const headerLines = bytesToAscii(visible.slice(0, headerEnd)).split('\r\n')
+	if(!/^HTTP\/1\.[01] [1-5][0-9][0-9](?: .*)?$/.test(headerLines[0] || '')) {
+		throw invalidClaim('TLS 1.2 CBC response has an invalid HTTP status line')
+	}
+	if(hasRedactedByte(redacted, 0, headerLines[0].length + 2)) {
+		throw invalidClaim('TLS 1.2 CBC response redacts HTTP status framing')
+	}
+
+	const contentLengths: string[] = []
+	const transferEncodings: string[] = []
+	let lineStart = headerLines[0].length + 2
+	for(const line of headerLines.slice(1)) {
+		const separator = line.indexOf(':')
+		if(separator <= 0) {
+			throw invalidClaim('TLS 1.2 CBC response has an invalid HTTP header')
+		}
+		const name = line.slice(0, separator).toLowerCase()
+		if(!/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(name)) {
+			throw invalidClaim('TLS 1.2 CBC response has an invalid HTTP header name')
+		}
+		let valueStart = separator + 1
+		while(valueStart < line.length && (line[valueStart] === ' ' || line[valueStart] === '\t')) {
+			valueStart++
+		}
+		const lineEnd = lineStart + line.length
+		if(hasRedactedByte(redacted, lineStart, lineStart + valueStart) ||
+			hasRedactedByte(redacted, lineEnd, lineEnd + 2)) {
+			throw invalidClaim('TLS 1.2 CBC response redacts HTTP header structure')
+		}
+		const value = line.slice(valueStart)
+		if(name === 'content-length') {
+			if(hasRedactedByte(redacted, lineStart, lineEnd)) {
+				throw invalidClaim('TLS 1.2 CBC response redacts a framing header')
+			}
+			contentLengths.push(value)
+		} else if(name === 'transfer-encoding') {
+			if(hasRedactedByte(redacted, lineStart, lineEnd)) {
+				throw invalidClaim('TLS 1.2 CBC response redacts a framing header')
+			}
+			transferEncodings.push(value)
+		}
+		lineStart = lineEnd + 2
+	}
+	if(hasRedactedByte(redacted, headerEnd + 2, headerEnd + 4)) {
+		throw invalidClaim('TLS 1.2 CBC response redacts the HTTP header terminator')
+	}
+
+	if(contentLengths.length > 1 || transferEncodings.length > 1 ||
+		(contentLengths.length > 0 && transferEncodings.length > 0)) {
+		throw invalidClaim('TLS 1.2 CBC response has ambiguous HTTP framing')
+	}
+
+	const bodyStart = headerEnd + 4
+	if(transferEncodings.length === 1) {
+		const codings = transferEncodings[0].split(',').map(value => value.trim().toLowerCase())
+		if(codings.some(value => value.length === 0)) {
+			throw invalidClaim('TLS 1.2 CBC response has an invalid Transfer-Encoding')
+		}
+		const chunkedIndex = codings.indexOf('chunked')
+		if(chunkedIndex >= 0) {
+			if(chunkedIndex !== codings.length - 1) {
+				throw invalidClaim('TLS 1.2 CBC response has invalid Transfer-Encoding order')
+			}
+			validateCompleteChunkedBody(visible, bodyStart)
+			return
+		}
+		if(!closeNotify) {
+			throw invalidClaim('TLS 1.2 CBC close-delimited response is missing authenticated close_notify')
+		}
+		return
+	}
+
+	if(contentLengths.length === 1) {
+		const value = contentLengths[0]
+		if(!/^[0-9]+$/.test(value)) {
+			throw invalidClaim('TLS 1.2 CBC response has an invalid Content-Length')
+		}
+		const contentLength = Number(value)
+		if(!Number.isSafeInteger(contentLength) || bodyStart + contentLength !== visible.length) {
+			throw invalidClaim('TLS 1.2 CBC response does not match its Content-Length')
+		}
+		return
+	}
+
+	if(!closeNotify) {
+		throw invalidClaim('TLS 1.2 CBC close-delimited response is missing authenticated close_notify')
+	}
+}
+
+function validateCompleteChunkedBody(response: Uint8Array, bodyStart: number): void {
+	let offset = bodyStart
+	for(;;) {
+		const lineEnd = findSequence(response, [13, 10], offset)
+		if(lineEnd < 0) {
+			throw invalidClaim('TLS 1.2 CBC chunked response has an incomplete size line')
+		}
+		const sizeLine = bytesToAscii(response.slice(offset, lineEnd))
+		const separator = sizeLine.indexOf(';')
+		const sizeText = (separator < 0 ? sizeLine : sizeLine.slice(0, separator)).trim()
+		if(!/^[0-9a-fA-F]+$/.test(sizeText)) {
+			throw invalidClaim('TLS 1.2 CBC chunked response has an invalid chunk size')
+		}
+		const chunkSize = Number.parseInt(sizeText, 16)
+		if(!Number.isSafeInteger(chunkSize)) {
+			throw invalidClaim('TLS 1.2 CBC chunked response has an invalid chunk size')
+		}
+		offset = lineEnd + 2
+
+		if(chunkSize === 0) {
+			for(;;) {
+				const trailerStart = offset
+				const trailerEnd = findSequence(response, [13, 10], offset)
+				if(trailerEnd < 0) {
+					throw invalidClaim('TLS 1.2 CBC chunked response has incomplete trailers')
+				}
+				offset = trailerEnd + 2
+				if(trailerEnd === trailerStart) {
+					if(offset !== response.length) {
+						throw invalidClaim('TLS 1.2 CBC chunked response has trailing bytes')
+					}
+					return
+				}
+			}
+		}
+
+		if(chunkSize > response.length - offset - 2) {
+			throw invalidClaim('TLS 1.2 CBC chunked response body is truncated')
+		}
+		offset += chunkSize
+		if(offset + 2 > response.length || response[offset] !== 13 || response[offset + 1] !== 10) {
+			throw invalidClaim('TLS 1.2 CBC chunked response is missing a data terminator')
+		}
+		offset += 2
+	}
+}
+
+function findSequence(data: Uint8Array, sequence: number[], start: number): number {
+	outer: for(let index = start; index <= data.length - sequence.length; index++) {
+		for(let offset = 0; offset < sequence.length; offset++) {
+			if(data[index + offset] !== sequence[offset]) {
+				continue outer
+			}
+		}
+		return index
+	}
+	return -1
+}
+
+function bytesToAscii(data: Uint8Array): string {
+	let result = ''
+	for(const value of data) {
+		result += String.fromCharCode(value)
+	}
+	return result
+}
+
+function hasRedactedByte(mask: Uint8Array, start: number, end: number): boolean {
+	for(let index = start; index < end; index++) {
+		if(mask[index] !== 0) {
+			return true
+		}
+	}
+	return false
 }
 
 function validateBinding(binding: TLS12CBCSessionBinding | undefined, owner: string): void {

--- a/src/server/utils/tee-oprf-mpc-verification.ts
+++ b/src/server/utils/tee-oprf-mpc-verification.ts
@@ -12,6 +12,8 @@ import type { OprfVerificationResult } from '#src/server/utils/tee-oprf-verifica
 import type { Logger } from '#src/types/general.ts'
 import { AttestorError } from '#src/utils/error.ts'
 
+export const MAX_TEE_OPRF_MPC_OUTPUTS = 20
+
 /**
  * Verifies OPRF MPC outputs from TEE_K and TEE_T match
  * Returns verified outputs for transcript replacement (same format as ZK OPRF)
@@ -23,6 +25,14 @@ export function verifyOprfMpcOutputs(
 ): OprfVerificationResult[] {
 	const kOutputs = kPayload.oprfOutputs || []
 	const tOutputs = tPayload.oprfOutputs || []
+	const responseLength = tPayload.tls12Cbc?.authenticatedRedactedResponse.length ||
+		tPayload.consolidatedResponseCiphertext.length
+	if(kOutputs.length > MAX_TEE_OPRF_MPC_OUTPUTS || tOutputs.length > MAX_TEE_OPRF_MPC_OUTPUTS) {
+		throw new AttestorError(
+			'ERROR_INVALID_CLAIM',
+			`Too many OPRF MPC outputs: maximum is ${MAX_TEE_OPRF_MPC_OUTPUTS}`
+		)
+	}
 
 	// Empty is valid - no OPRF MPC was requested
 	if(kOutputs.length === 0 && tOutputs.length === 0) {
@@ -79,6 +89,24 @@ export function verifyOprfMpcOutputs(
 				`TEE_K [${kOut.tlsStart}:${kOut.tlsStart + kOut.tlsLength}] vs ` +
 				`TEE_T [${tOut.tlsStart}:${tOut.tlsStart + tOut.tlsLength}]`
 			)
+		}
+
+		if(kOut.tlsStart > responseLength || kOut.tlsLength > responseLength - kOut.tlsStart) {
+			throw new AttestorError(
+				'ERROR_INVALID_CLAIM',
+				`OPRF MPC range at index ${i} exceeds authenticated response length ${responseLength}`
+			)
+		}
+
+		const rangeEnd = kOut.tlsStart + kOut.tlsLength
+		for(const previous of results) {
+			const previousEnd = previous.position + previous.length
+			if(kOut.tlsStart < previousEnd && rangeEnd > previous.position) {
+				throw new AttestorError(
+					'ERROR_INVALID_CLAIM',
+					`OPRF MPC ranges overlap: [${previous.position}:${previousEnd}] and [${kOut.tlsStart}:${rangeEnd}]`
+				)
+			}
 		}
 
 		// Verify hash outputs match (hash = SHA256(CMAC), so this implies CMAC matched too)

--- a/src/server/utils/tee-oprf-mpc-verification.ts
+++ b/src/server/utils/tee-oprf-mpc-verification.ts
@@ -25,9 +25,10 @@ export function verifyOprfMpcOutputs(
 ): OprfVerificationResult[] {
 	const kOutputs = kPayload.oprfOutputs || []
 	const tOutputs = tPayload.oprfOutputs || []
-	const responseLength = tPayload.tls12Cbc?.authenticatedRedactedResponse.length ||
-		tPayload.consolidatedResponseCiphertext.length
-	if(kOutputs.length > MAX_TEE_OPRF_MPC_OUTPUTS || tOutputs.length > MAX_TEE_OPRF_MPC_OUTPUTS) {
+	const isTls12Cbc = tPayload.tls12Cbc !== undefined
+	const responseLength = tPayload.tls12Cbc?.authenticatedRedactedResponse.length ?? 0
+	if(isTls12Cbc &&
+		(kOutputs.length > MAX_TEE_OPRF_MPC_OUTPUTS || tOutputs.length > MAX_TEE_OPRF_MPC_OUTPUTS)) {
 		throw new AttestorError(
 			'ERROR_INVALID_CLAIM',
 			`Too many OPRF MPC outputs: maximum is ${MAX_TEE_OPRF_MPC_OUTPUTS}`
@@ -91,21 +92,24 @@ export function verifyOprfMpcOutputs(
 			)
 		}
 
-		if(kOut.tlsStart > responseLength || kOut.tlsLength > responseLength - kOut.tlsStart) {
+		if(isTls12Cbc &&
+			(kOut.tlsStart > responseLength || kOut.tlsLength > responseLength - kOut.tlsStart)) {
 			throw new AttestorError(
 				'ERROR_INVALID_CLAIM',
 				`OPRF MPC range at index ${i} exceeds authenticated response length ${responseLength}`
 			)
 		}
 
-		const rangeEnd = kOut.tlsStart + kOut.tlsLength
-		for(const previous of results) {
-			const previousEnd = previous.position + previous.length
-			if(kOut.tlsStart < previousEnd && rangeEnd > previous.position) {
-				throw new AttestorError(
-					'ERROR_INVALID_CLAIM',
-					`OPRF MPC ranges overlap: [${previous.position}:${previousEnd}] and [${kOut.tlsStart}:${rangeEnd}]`
-				)
+		if(isTls12Cbc) {
+			const rangeEnd = kOut.tlsStart + kOut.tlsLength
+			for(const previous of results) {
+				const previousEnd = previous.position + previous.length
+				if(kOut.tlsStart < previousEnd && rangeEnd > previous.position) {
+					throw new AttestorError(
+						'ERROR_INVALID_CLAIM',
+						`OPRF MPC ranges overlap: [${previous.position}:${previousEnd}] and [${kOut.tlsStart}:${rangeEnd}]`
+					)
+				}
 			}
 		}
 

--- a/src/server/utils/tee-transcript-reconstruction.ts
+++ b/src/server/utils/tee-transcript-reconstruction.ts
@@ -179,7 +179,7 @@ async function reconstructConsolidatedResponse(bundleData: TeeBundleData, logger
 	// offset and the verifier's dechunk would desync ("got more data after response
 	// was complete"). Non-TEE / legacy flows leave framing in place and dechunk inside
 	// the http provider using the same parser.
-	const dechunked = dechunkRevealedResponse(processedResponse, oprf, logger)
+	const dechunked = dechunkRevealedResponse(processedResponse, oprf, logger, isTls12Cbc)
 	processedResponse = dechunked.response
 	oprf = dechunked.oprfResults
 
@@ -208,7 +208,8 @@ const DECHUNK_SYNTH_HEADER = 'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\
 function dechunkRevealedResponse(
 	response: Uint8Array,
 	oprfResults: Array<{ position: number, length: number, output: Uint8Array }> | undefined,
-	logger: Logger
+	logger: Logger,
+	strictOprfRanges: boolean,
 ): { response: Uint8Array, oprfResults?: Array<{ position: number, length: number, output: Uint8Array }> } {
 	const headerEnd = findHeaderEnd(response)
 	if(headerEnd < 0) {
@@ -221,17 +222,35 @@ function dechunkRevealedResponse(
 		return { response, oprfResults }
 	}
 
-	// Dechunk via the same synthetic-header parse the http provider uses, so chunk
-	// detection is identical. res.chunks positions are offset by the synthetic prefix.
-	const parser = makeHttpResponseParser()
-	parser.onChunk(strToUint8Array(DECHUNK_SYNTH_HEADER))
-	parser.onChunk(response.slice(bodyStart))
-	const chunks = parser.res.chunks
-	if(!chunks || chunks.length === 0) {
-		return { response, oprfResults }
-	}
+	let dechunkedBody: Uint8Array
+	let remapped: Array<{ position: number, length: number, output: Uint8Array }> | undefined
+	let chunkCount: number
+	if(strictOprfRanges) {
+		// CBC framing was authenticated and validated before reconstruction. Parse
+		// trailers here because the legacy HTTP parser deliberately stops at the
+		// zero chunk and rejects non-empty trailer lines.
+		const parsed = dechunkCompleteCbcBody(response, bodyStart)
+		dechunkedBody = parsed.body
+		chunkCount = parsed.chunks.length
+		remapped = oprfResults?.map(r => remapCbcChunkedOprfRange(r, bodyStart, parsed.chunks))
+	} else {
+		// Preserve the exact pre-CBC parser and coordinate mapping.
+		const parser = makeHttpResponseParser()
+		parser.onChunk(strToUint8Array(DECHUNK_SYNTH_HEADER))
+		parser.onChunk(response.slice(bodyStart))
+		const chunks = parser.res.chunks
+		if(!chunks || chunks.length === 0) {
+			return { response, oprfResults }
+		}
 
-	const dechunkedBody = parser.res.body ?? new Uint8Array()
+		dechunkedBody = parser.res.body ?? new Uint8Array()
+		chunkCount = chunks.length
+		const synthLen = DECHUNK_SYNTH_HEADER.length
+		remapped = oprfResults?.map(r => ({
+			...r,
+			position: chunkedToDechunkedPos(r.position, bodyStart, synthLen, chunks),
+		}))
+	}
 
 	// Blank the transfer-encoding token so the provider's dechunk is skipped.
 	const headerRegion = response.slice(0, bodyStart)
@@ -246,10 +265,7 @@ function dechunkRevealedResponse(
 	dechunkedResponse.set(headerRegion, 0)
 	dechunkedResponse.set(dechunkedBody, headerRegion.length)
 
-	const synthLen = DECHUNK_SYNTH_HEADER.length
-	const remapped = oprfResults?.map(r => remapChunkedOprfRange(r, bodyStart, synthLen, chunks))
-
-	logger.info(`TEE dechunk before OPRF: ${response.length} -> ${dechunkedResponse.length} bytes, ${chunks.length} chunks`)
+	logger.info(`TEE dechunk before OPRF: ${response.length} -> ${dechunkedResponse.length} bytes, ${chunkCount} chunks`)
 	return { response: dechunkedResponse, oprfResults: remapped }
 }
 
@@ -268,10 +284,9 @@ function findHeaderEnd(response: Uint8Array): number {
 // Map a position in the original (chunked) response to its position in the dechunked
 // response. `chunks` are in synthetic-prefixed coords (fromIndex/toIndex point to chunk
 // DATA), so subtract `synthLen` to get body-relative offsets.
-function remapChunkedOprfRange(
+function remapCbcChunkedOprfRange(
 	range: { position: number, length: number, output: Uint8Array },
 	bodyStart: number,
-	synthLen: number,
 	chunks: Array<{ fromIndex: number, toIndex: number }>
 ): { position: number, length: number, output: Uint8Array } {
 	const rangeEnd = range.position + range.length
@@ -282,26 +297,122 @@ function remapChunkedOprfRange(
 		return range
 	}
 
-	const bodyOff = range.position - bodyStart
-	const bodyEnd = rangeEnd - bodyStart
 	let acc = 0
 	for(const c of chunks) {
-		const cf = c.fromIndex - synthLen
-		const ct = c.toIndex - synthLen
-		if(bodyOff >= cf && bodyEnd <= ct) {
+		if(range.position >= c.fromIndex && rangeEnd <= c.toIndex) {
 			return {
 				...range,
-				position: bodyStart + acc + (bodyOff - cf),
+				position: bodyStart + acc + (range.position - c.fromIndex),
 			}
 		}
 
-		acc += ct - cf
+		acc += c.toIndex - c.fromIndex
 	}
 
 	throw new AttestorError(
 		'ERROR_INVALID_CLAIM',
 		`OPRF range [${range.position}:${rangeEnd}] is not wholly contained in HTTP chunk data`
 	)
+}
+
+function dechunkCompleteCbcBody(
+	response: Uint8Array,
+	bodyStart: number,
+): { body: Uint8Array, chunks: Array<{ fromIndex: number, toIndex: number }> } {
+	const bodyParts: Uint8Array[] = []
+	const chunks: Array<{ fromIndex: number, toIndex: number }> = []
+	let offset = bodyStart
+	for(;;) {
+		const lineEnd = findCrlf(response, offset)
+		if(lineEnd < 0) {
+			throw new AttestorError('ERROR_INVALID_CLAIM', 'CBC chunk size line is incomplete during reconstruction')
+		}
+		const sizeLine = uint8ArrayToStr(response.slice(offset, lineEnd))
+		const extension = sizeLine.indexOf(';')
+		const sizeText = (extension < 0 ? sizeLine : sizeLine.slice(0, extension)).trim()
+		if(!/^[0-9a-fA-F]+$/.test(sizeText)) {
+			throw new AttestorError('ERROR_INVALID_CLAIM', 'CBC chunk size is invalid during reconstruction')
+		}
+		const size = Number.parseInt(sizeText, 16)
+		offset = lineEnd + 2
+
+		if(size === 0) {
+			for(;;) {
+				const trailerEnd = findCrlf(response, offset)
+				if(trailerEnd < 0) {
+					throw new AttestorError('ERROR_INVALID_CLAIM', 'CBC chunk trailers are incomplete during reconstruction')
+				}
+				const trailerStart = offset
+				offset = trailerEnd + 2
+				if(trailerEnd === trailerStart) {
+					if(offset !== response.length) {
+						throw new AttestorError('ERROR_INVALID_CLAIM', 'CBC chunked response has trailing bytes during reconstruction')
+					}
+					return { body: concatenateParts(bodyParts), chunks }
+				}
+			}
+		}
+
+		const dataEnd = offset + size
+		if(dataEnd + 2 > response.length || response[dataEnd] !== 13 || response[dataEnd + 1] !== 10) {
+			throw new AttestorError('ERROR_INVALID_CLAIM', 'CBC chunk data is incomplete during reconstruction')
+		}
+		chunks.push({ fromIndex: offset, toIndex: dataEnd })
+		bodyParts.push(response.slice(offset, dataEnd))
+		offset = dataEnd + 2
+	}
+}
+
+function findCrlf(response: Uint8Array, start: number): number {
+	for(let index = start; index + 1 < response.length; index++) {
+		if(response[index] === 13 && response[index + 1] === 10) {
+			return index
+		}
+	}
+	return -1
+}
+
+function concatenateParts(parts: Uint8Array[]): Uint8Array {
+	const length = parts.reduce((total, part) => total + part.length, 0)
+	const result = new Uint8Array(length)
+	let offset = 0
+	for(const part of parts) {
+		result.set(part, offset)
+		offset += part.length
+	}
+	return result
+}
+
+// Keep the pre-CBC position mapping byte-for-byte equivalent. Legacy bundles
+// historically allowed positions at chunk boundaries and beyond the last
+// parsed chunk; tightening those rules would reject previously valid claims.
+function chunkedToDechunkedPos(
+	pos: number,
+	bodyStart: number,
+	synthLen: number,
+	chunks: Array<{ fromIndex: number, toIndex: number }>
+): number {
+	if(pos < bodyStart) {
+		return pos
+	}
+
+	const bodyOff = pos - bodyStart
+	let acc = 0
+	for(const c of chunks) {
+		const cf = c.fromIndex - synthLen
+		const ct = c.toIndex - synthLen
+		if(bodyOff >= cf && bodyOff < ct) {
+			return bodyStart + acc + (bodyOff - cf)
+		}
+
+		if(bodyOff === ct) {
+			return bodyStart + acc + (ct - cf)
+		}
+
+		acc += ct - cf
+	}
+
+	return bodyStart + acc
 }
 
 // Removed legacy packet-based extraction functions since we now use consolidated streams

--- a/src/server/utils/tee-transcript-reconstruction.ts
+++ b/src/server/utils/tee-transcript-reconstruction.ts
@@ -61,20 +61,27 @@ export async function reconstructTlsTranscript(
  * Reconstructs the original request by applying proof stream to redacted request
  */
 function reconstructRequest(bundleData: TeeBundleData, logger: Logger): Uint8Array {
-	const { kOutputPayload } = bundleData
+	const { kOutputPayload, protocolMode } = bundleData
+	const cbcContract = kOutputPayload.tls12Cbc
+	const redactedRequest = protocolMode === 'tls12-cbc'
+		? cbcContract!.authenticatedRedactedRequest
+		: kOutputPayload.redactedRequest
+	const requestRedactionRanges = protocolMode === 'tls12-cbc'
+		? cbcContract!.requestRedactionRanges
+		: kOutputPayload.requestRedactionRanges
 
-	if(!kOutputPayload.requestRedactionRanges || kOutputPayload.requestRedactionRanges.length === 0) {
+	if(requestRedactionRanges.length === 0) {
 		logger.warn('No request redaction ranges - using redacted request as-is')
-		return kOutputPayload.redactedRequest
+		return redactedRequest
 	}
 
 	// Create a copy of the redacted request
-	const revealedRequest = new Uint8Array(kOutputPayload.redactedRequest)
+	const revealedRequest = new Uint8Array(redactedRequest)
 
 	// Create pretty display: show revealed proof data, but keep other sensitive data as '*'
 	const prettyRequest = new Uint8Array(revealedRequest)
 
-	for(const range of kOutputPayload.requestRedactionRanges) {
+	for(const range of requestRedactionRanges) {
 		// Keep non-proof sensitive data as '*' for display
 		if(!range.type.includes('proof')) {
 			const start = range.start
@@ -98,62 +105,70 @@ async function reconstructConsolidatedResponse(bundleData: TeeBundleData, logger
 	length: number
 	output: Uint8Array
 }>): Promise<Uint8Array> {
-	const { kOutputPayload, tOutputPayload } = bundleData
+	const { kOutputPayload, tOutputPayload, protocolMode } = bundleData
+	const isTls12Cbc = protocolMode === 'tls12-cbc'
+	let reconstructedResponse: Uint8Array
+	let responseRedactionRanges: Array<{ start: number, length: number }>
 
-	// Get consolidated data from both TEEs
-	const consolidatedKeystream = kOutputPayload.consolidatedResponseKeystream
-	const consolidatedCiphertext = tOutputPayload.consolidatedResponseCiphertext
+	if(isTls12Cbc) {
+		reconstructedResponse = new Uint8Array(tOutputPayload.tls12Cbc!.authenticatedRedactedResponse)
+		responseRedactionRanges = tOutputPayload.tls12Cbc!.responseRedactionRanges
+	} else {
+		const consolidatedKeystream = kOutputPayload.consolidatedResponseKeystream
+		const consolidatedCiphertext = tOutputPayload.consolidatedResponseCiphertext
 
-	if(!consolidatedKeystream || consolidatedKeystream.length === 0) {
-		throw new AttestorError('ERROR_INVALID_CLAIM', 'No consolidated response keystream available')
+		if(consolidatedKeystream.length === 0) {
+			throw new AttestorError('ERROR_INVALID_CLAIM', 'No consolidated response keystream available')
+		}
+
+		if(consolidatedCiphertext.length === 0) {
+			throw new AttestorError('ERROR_INVALID_CLAIM', 'No consolidated response ciphertext available')
+		}
+
+		if(consolidatedKeystream.length !== consolidatedCiphertext.length) {
+			logger.warn('Keystream and ciphertext length mismatch', {
+				keystreamLength: consolidatedKeystream.length,
+				ciphertextLength: consolidatedCiphertext.length
+			})
+		}
+
+		const minLength = Math.min(consolidatedKeystream.length, consolidatedCiphertext.length)
+		reconstructedResponse = new Uint8Array(minLength)
+		for(let i = 0; i < minLength; i++) {
+			reconstructedResponse[i] = consolidatedKeystream[i] ^ consolidatedCiphertext[i]
+		}
+		responseRedactionRanges = kOutputPayload.responseRedactionRanges
 	}
 
-	if(!consolidatedCiphertext || consolidatedCiphertext.length === 0) {
-		throw new AttestorError('ERROR_INVALID_CLAIM', 'No consolidated response ciphertext available')
-	}
+	logger.info(`Reconstructed response: ${reconstructedResponse.length} bytes, ${responseRedactionRanges.length} redaction ranges`)
 
-	// Verify lengths match
-	if(consolidatedKeystream.length !== consolidatedCiphertext.length) {
-		logger.warn('Keystream and ciphertext length mismatch', {
-			keystreamLength: consolidatedKeystream.length,
-			ciphertextLength: consolidatedCiphertext.length
-		})
-	}
-
-	// XOR to get plaintext (keystream XOR ciphertext = plaintext)
-	const minLength = Math.min(consolidatedKeystream.length, consolidatedCiphertext.length)
-	const reconstructedResponse = new Uint8Array(minLength)
-
-	for(let i = 0; i < minLength; i++) {
-		reconstructedResponse[i] = consolidatedKeystream[i] ^ consolidatedCiphertext[i]
-	}
-
-	logger.info(`Reconstructed response: ${reconstructedResponse.length} bytes, ${kOutputPayload.responseRedactionRanges?.length || 0} redaction ranges`)
-
-	// Apply response redaction ranges to the reconstructed response
-	let processedResponse = applyResponseRedactionRanges(reconstructedResponse, kOutputPayload.responseRedactionRanges, logger)
+	// CBC carries authenticated redacted plaintext directly. Split AEAD first
+	// reconstructs plaintext by XOR. Both modes then use their signed ranges.
+	let processedResponse = applyResponseRedactionRanges(reconstructedResponse, responseRedactionRanges, logger)
 
 	// Trim leading (NewSessionTicket) and trailing (close_notify/alert) asterisks
 	// BEFORE OPRF/dechunk so downstream positions are stable.
 	let leadingAsterisks = 0
-	for(const element of processedResponse) {
-		if(element === REDACTION_CHAR_CODE) {
-			leadingAsterisks++
-		} else {
-			break
-		}
-	}
-
 	let trailingAsterisks = 0
-	for(let i = processedResponse.length - 1; i >= leadingAsterisks; i--) {
-		if(processedResponse[i] === REDACTION_CHAR_CODE) {
-			trailingAsterisks++
-		} else {
-			break
+	if(!isTls12Cbc) {
+		for(const element of processedResponse) {
+			if(element === REDACTION_CHAR_CODE) {
+				leadingAsterisks++
+			} else {
+				break
+			}
 		}
-	}
 
-	processedResponse = processedResponse.slice(leadingAsterisks, processedResponse.length - trailingAsterisks)
+		for(let i = processedResponse.length - 1; i >= leadingAsterisks; i--) {
+			if(processedResponse[i] === REDACTION_CHAR_CODE) {
+				trailingAsterisks++
+			} else {
+				break
+			}
+		}
+
+		processedResponse = processedResponse.slice(leadingAsterisks, processedResponse.length - trailingAsterisks)
+	}
 
 	// OPRF positions are in pre-trim coords; shift them into trimmed coords.
 	let oprf = oprfResults?.map(r => ({ ...r, position: r.position - leadingAsterisks }))
@@ -232,10 +247,7 @@ function dechunkRevealedResponse(
 	dechunkedResponse.set(dechunkedBody, headerRegion.length)
 
 	const synthLen = DECHUNK_SYNTH_HEADER.length
-	const remapped = oprfResults?.map(r => ({
-		...r,
-		position: chunkedToDechunkedPos(r.position, bodyStart, synthLen, chunks)
-	}))
+	const remapped = oprfResults?.map(r => remapChunkedOprfRange(r, bodyStart, synthLen, chunks))
 
 	logger.info(`TEE dechunk before OPRF: ${response.length} -> ${dechunkedResponse.length} bytes, ${chunks.length} chunks`)
 	return { response: dechunkedResponse, oprfResults: remapped }
@@ -256,33 +268,40 @@ function findHeaderEnd(response: Uint8Array): number {
 // Map a position in the original (chunked) response to its position in the dechunked
 // response. `chunks` are in synthetic-prefixed coords (fromIndex/toIndex point to chunk
 // DATA), so subtract `synthLen` to get body-relative offsets.
-function chunkedToDechunkedPos(
-	pos: number,
+function remapChunkedOprfRange(
+	range: { position: number, length: number, output: Uint8Array },
 	bodyStart: number,
 	synthLen: number,
 	chunks: Array<{ fromIndex: number, toIndex: number }>
-): number {
-	if(pos < bodyStart) {
-		return pos
+): { position: number, length: number, output: Uint8Array } {
+	const rangeEnd = range.position + range.length
+	if(range.position < bodyStart) {
+		if(rangeEnd > bodyStart) {
+			throw new AttestorError('ERROR_INVALID_CLAIM', 'OPRF range crosses the HTTP header boundary')
+		}
+		return range
 	}
 
-	const bodyOff = pos - bodyStart
+	const bodyOff = range.position - bodyStart
+	const bodyEnd = rangeEnd - bodyStart
 	let acc = 0
 	for(const c of chunks) {
 		const cf = c.fromIndex - synthLen
 		const ct = c.toIndex - synthLen
-		if(bodyOff >= cf && bodyOff < ct) {
-			return bodyStart + acc + (bodyOff - cf)
-		}
-
-		if(bodyOff === ct) {
-			return bodyStart + acc + (ct - cf)
+		if(bodyOff >= cf && bodyEnd <= ct) {
+			return {
+				...range,
+				position: bodyStart + acc + (bodyOff - cf),
+			}
 		}
 
 		acc += ct - cf
 	}
 
-	return bodyStart + acc
+	throw new AttestorError(
+		'ERROR_INVALID_CLAIM',
+		`OPRF range [${range.position}:${rangeEnd}] is not wholly contained in HTTP chunk data`
+	)
 }
 
 // Removed legacy packet-based extraction functions since we now use consolidated streams

--- a/src/server/utils/tee-verification.ts
+++ b/src/server/utils/tee-verification.ts
@@ -16,12 +16,6 @@ import type { Logger } from '#src/types/general.ts'
 import { AttestorError } from '#src/utils/error.ts'
 import { SIGNATURES } from '#src/utils/signatures/index.ts'
 
-// Both transcript bodies can carry up to 500 TLS plaintext records. Ten MiB
-// leaves room for protobuf metadata over the 8,192,000-byte record limit.
-export const MAX_TEE_SIGNED_BODY_SIZE = 10 * 1024 * 1024
-// A legacy bundle can contain one maximum response in each signed body.
-export const MAX_TEE_VERIFICATION_BUNDLE_SIZE = 24 * 1024 * 1024
-
 // Types specific to TEE verification
 export interface TeeBundleData {
 	teekSigned: SignedMessage
@@ -50,9 +44,6 @@ export async function verifyTeeBundle(
 	bundleBytes: Uint8Array,
 	logger: Logger
 ): Promise<TeeBundleData> {
-	if(bundleBytes.length > MAX_TEE_VERIFICATION_BUNDLE_SIZE) {
-		throw new AttestorError('ERROR_INVALID_CLAIM', 'TEE verification bundle exceeds the maximum size')
-	}
 	// Parse the verification bundle protobuf
 	const bundle = parseVerificationBundle(bundleBytes)
 
@@ -157,11 +148,6 @@ function validateBundleCompleteness(bundle: VerificationBundle): void {
 
 	if(!bundle.teetSigned.body || bundle.teetSigned.body.length === 0) {
 		throw new Error('Invalid TEE_T signed message: empty body')
-	}
-
-	if(bundle.teekSigned.body.length > MAX_TEE_SIGNED_BODY_SIZE ||
-		bundle.teetSigned.body.length > MAX_TEE_SIGNED_BODY_SIZE) {
-		throw new AttestorError('ERROR_INVALID_CLAIM', 'TEE signed body exceeds the maximum size')
 	}
 
 	if(!bundle.teekSigned.signature || bundle.teekSigned.signature.length === 0) {

--- a/src/server/utils/tee-verification.ts
+++ b/src/server/utils/tee-verification.ts
@@ -10,9 +10,17 @@ import { validateGcpAttestationAndExtractKey } from '#src/server/utils/gcp-attes
 import type { AddressExtractionResult } from '#src/server/utils/nitro-attestation.ts'
 import { assertSevSnpBaseAllowed } from '#src/server/utils/sev-snp/allowlist.ts'
 import { verifyCombinedSecureBoot, verifyCombinedSevSnp } from '#src/server/utils/sev-snp/verify.ts'
+import type { TeeProtocolMode } from '#src/server/utils/tee-cbc-contract.ts'
+import { validateTeeTranscriptContract } from '#src/server/utils/tee-cbc-contract.ts'
 import type { Logger } from '#src/types/general.ts'
 import { AttestorError } from '#src/utils/error.ts'
 import { SIGNATURES } from '#src/utils/signatures/index.ts'
+
+// Both transcript bodies can carry up to 500 TLS plaintext records. Ten MiB
+// leaves room for protobuf metadata over the 8,192,000-byte record limit.
+export const MAX_TEE_SIGNED_BODY_SIZE = 10 * 1024 * 1024
+// A legacy bundle can contain one maximum response in each signed body.
+export const MAX_TEE_VERIFICATION_BUNDLE_SIZE = 24 * 1024 * 1024
 
 // Types specific to TEE verification
 export interface TeeBundleData {
@@ -23,6 +31,7 @@ export interface TeeBundleData {
 	teekPcr0: string
 	teetPcr0: string
 	teeSessionId: string
+	protocolMode: TeeProtocolMode
 }
 
 export interface TeeSignatureVerificationResult {
@@ -41,6 +50,9 @@ export async function verifyTeeBundle(
 	bundleBytes: Uint8Array,
 	logger: Logger
 ): Promise<TeeBundleData> {
+	if(bundleBytes.length > MAX_TEE_VERIFICATION_BUNDLE_SIZE) {
+		throw new AttestorError('ERROR_INVALID_CLAIM', 'TEE verification bundle exceeds the maximum size')
+	}
 	// Parse the verification bundle protobuf
 	const bundle = parseVerificationBundle(bundleBytes)
 
@@ -69,6 +81,10 @@ export async function verifyTeeBundle(
 
 	validateSignedAttestationTypes(bundle, kOutputPayload, tOutputPayload)
 
+	// Select and validate one complete signed transcript contract. This runs
+	// only after both TEE signatures have been verified.
+	const protocolMode = validateTeeTranscriptContract(bundle, kOutputPayload, tOutputPayload)
+
 	// Validate timestamps
 	validateTimestamps(kOutputPayload, tOutputPayload, logger)
 
@@ -85,6 +101,7 @@ export async function verifyTeeBundle(
 		teekPcr0: teekKeyResult!.pcr0,
 		teetPcr0: teetKeyResult!.pcr0,
 		teeSessionId,
+		protocolMode,
 	}
 }
 
@@ -140,6 +157,11 @@ function validateBundleCompleteness(bundle: VerificationBundle): void {
 
 	if(!bundle.teetSigned.body || bundle.teetSigned.body.length === 0) {
 		throw new Error('Invalid TEE_T signed message: empty body')
+	}
+
+	if(bundle.teekSigned.body.length > MAX_TEE_SIGNED_BODY_SIZE ||
+		bundle.teetSigned.body.length > MAX_TEE_SIGNED_BODY_SIZE) {
+		throw new AttestorError('ERROR_INVALID_CLAIM', 'TEE signed body exceeds the maximum size')
 	}
 
 	if(!bundle.teekSigned.signature || bundle.teekSigned.signature.length === 0) {
@@ -536,15 +558,6 @@ function parseKOutputPayload(signedMessage: SignedMessage): KOutputPayload {
 	// Use actual protobuf decoding
 	const payload = KOutputPayload.decode(signedMessage.body)
 
-	// Validate required fields
-	if(!payload.redactedRequest) {
-		throw new Error('Missing redacted request in TEE_K payload')
-	}
-
-	if(!payload.consolidatedResponseKeystream || payload.consolidatedResponseKeystream.length === 0) {
-		throw new Error('Missing consolidated response keystream in TEE_K payload')
-	}
-
 	if(!payload.certificateInfo) {
 		throw new Error('Missing certificate info in TEE_K payload')
 	}
@@ -559,12 +572,6 @@ function parseKOutputPayload(signedMessage: SignedMessage): KOutputPayload {
 function parseTOutputPayload(signedMessage: SignedMessage): TOutputPayload {
 	// Use actual protobuf decoding
 	const payload = TOutputPayload.decode(signedMessage.body)
-
-	// Validate required fields
-	if(!payload.consolidatedResponseCiphertext || payload.consolidatedResponseCiphertext.length === 0) {
-		throw new Error('Missing consolidated response ciphertext in TEE_T payload')
-	}
-
 
 	return payload
 }

--- a/src/tests/tee-cbc-contract.test.ts
+++ b/src/tests/tee-cbc-contract.test.ts
@@ -18,16 +18,10 @@ import {
 	TOutputPayload,
 	VerificationBundle,
 } from '#src/proto/tee-bundle.ts'
-import { validateAndCombineOprfResults } from '#src/server/handlers/claimTeeBundle.ts'
 import { validateTeeTranscriptContract } from '#src/server/utils/tee-cbc-contract.ts'
 import { MAX_TEE_OPRF_MPC_OUTPUTS, verifyOprfMpcOutputs } from '#src/server/utils/tee-oprf-mpc-verification.ts'
 import { reconstructTlsTranscript } from '#src/server/utils/tee-transcript-reconstruction.ts'
-import {
-	MAX_TEE_SIGNED_BODY_SIZE,
-	MAX_TEE_VERIFICATION_BUNDLE_SIZE,
-	type TeeBundleData,
-	verifyTeeBundle,
-} from '#src/server/utils/tee-verification.ts'
+import { type TeeBundleData, verifyTeeBundle } from '#src/server/utils/tee-verification.ts'
 import { logger } from '#src/utils/logger.ts'
 import { ETH_SIGNATURE_PROVIDER } from '#src/utils/signatures/eth.ts'
 
@@ -61,8 +55,8 @@ describe('TEE TLS 1.2 CBC contract', () => {
 		const contract = makeCbcContract(
 			encoder.encode('GET /signed HTTP/1.1\r\n\r\n'),
 			encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK'),
-			0,
-			0,
+			99,
+			99,
 		)
 		const teekWallet = Wallet.createRandom()
 		const teetWallet = Wallet.createRandom()
@@ -153,7 +147,12 @@ describe('TEE TLS 1.2 CBC contract', () => {
 			0xc024, 0xc028, 0x002f, 0x0035, 0x003c, 0x003d,
 		]
 		for(const cipherSuite of suites) {
-			const contract = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 99, 99)
+			const contract = makeCbcContract(
+				encoder.encode('request'),
+				encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK'),
+				99,
+				99,
+			)
 			contract.kPayload.tls12Cbc!.binding!.cipherSuite = cipherSuite
 			contract.tPayload.tls12Cbc!.binding!.cipherSuite = cipherSuite
 			assert.equal(
@@ -161,6 +160,154 @@ describe('TEE TLS 1.2 CBC contract', () => {
 				'tls12-cbc',
 			)
 		}
+	})
+
+	it('caps CBC requests at one TLS plaintext record', () => {
+		const response = encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK')
+		const maximum = makeCbcContract(new Uint8Array(16_384), response, 99_999, 99_999)
+		assert.equal(validateTeeTranscriptContract(maximum.bundle, maximum.kPayload, maximum.tPayload), 'tls12-cbc')
+
+		const oversized = makeCbcContract(new Uint8Array(16_385), response, 99_999, 99_999)
+		assert.throws(
+			() => validateTeeTranscriptContract(oversized.bundle, oversized.kPayload, oversized.tPayload),
+			/authenticated request length/,
+		)
+	})
+
+	it('requires complete CBC Content-Length and chunked responses', () => {
+		const request = encoder.encode('request')
+		const validResponses = [
+			'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK',
+			'HTTP/1.1 200 OK\r\nContent-Length: 02\r\n\r\nOK',
+			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2\r\nOK\r\n0\r\n\r\n',
+			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2;hidden=VALUE\r\nOK\r\n0\r\nX-Trailer: value\r\n\r\n',
+		]
+		for(const response of validResponses) {
+			const contract = makeCbcContract(request, encoder.encode(response), 99, 99)
+			assert.equal(validateTeeTranscriptContract(contract.bundle, contract.kPayload, contract.tPayload), 'tls12-cbc')
+		}
+
+		const responseWithHiddenMetadata = encoder.encode(
+			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2;hidden=VALUE\r\nOK\r\n0\r\nX-Trailer: value\r\n\r\n',
+		)
+		const hiddenMetadata = makeCbcContract(request, responseWithHiddenMetadata, 99, 99)
+		hiddenMetadata.tPayload.tls12Cbc!.responseRedactionRanges = [
+			{ start: findBytes(responseWithHiddenMetadata, encoder.encode('hidden=VALUE')), length: 'hidden=VALUE'.length },
+			{ start: findBytes(responseWithHiddenMetadata, encoder.encode('X-Trailer: value')), length: 'X-Trailer: value'.length },
+		]
+		assert.equal(
+			validateTeeTranscriptContract(hiddenMetadata.bundle, hiddenMetadata.kPayload, hiddenMetadata.tPayload),
+			'tls12-cbc',
+		)
+
+		const responseWithHiddenHeader = encoder.encode(
+			'HTTP/1.1 200 OK\r\nX-Secret: TOKEN\r\nContent-Length: 2\r\n\r\nOK',
+		)
+		const hiddenHeader = makeCbcContract(request, responseWithHiddenHeader, 99, 99)
+		hiddenHeader.tPayload.tls12Cbc!.responseRedactionRanges = [{
+			start: findBytes(responseWithHiddenHeader, encoder.encode('TOKEN')),
+			length: 'TOKEN'.length,
+		}]
+		assert.equal(
+			validateTeeTranscriptContract(hiddenHeader.bundle, hiddenHeader.kPayload, hiddenHeader.tPayload),
+			'tls12-cbc',
+		)
+
+		const invalidResponses = [
+			'HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nOK',
+			'HTTP/1.1 200 OK\r\nContent-Length: 2 \r\n\r\nOK',
+			'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOKextra',
+			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2\r\nOK\r\n',
+			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2\r\nOK\r\n0\r\n',
+			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2\r\nOK\r\n0\r\n\r\nextra',
+		]
+		for(const response of invalidResponses) {
+			const contract = makeCbcContract(request, encoder.encode(response), 99, 99)
+			assert.throws(
+				() => validateTeeTranscriptContract(contract.bundle, contract.kPayload, contract.tPayload),
+				/TLS 1\.2 CBC/,
+			)
+		}
+
+		const hiddenFraming = makeCbcContract(
+			request,
+			encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK'),
+			99,
+			99,
+		)
+		hiddenFraming.tPayload.tls12Cbc!.responseRedactionRanges = [{
+			start: findBytes(hiddenFraming.tPayload.tls12Cbc!.authenticatedRedactedResponse, encoder.encode('Content-Length')),
+			length: 'Content-Length'.length,
+		}]
+		hiddenFraming.tPayload.tls12Cbc!.closeNotify = true
+		assert.throws(
+			() => validateTeeTranscriptContract(hiddenFraming.bundle, hiddenFraming.kPayload, hiddenFraming.tPayload),
+			/redacts HTTP header structure/,
+		)
+
+		const hiddenTransferEncoding = makeCbcContract(
+			request,
+			encoder.encode('HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nA\r\n0\r\n\r\n'),
+			99,
+			99,
+		)
+		hiddenTransferEncoding.tPayload.tls12Cbc!.responseRedactionRanges = [{
+			start: findBytes(
+				hiddenTransferEncoding.tPayload.tls12Cbc!.authenticatedRedactedResponse,
+				encoder.encode('chunked'),
+			),
+			length: 'chunked'.length,
+		}]
+		hiddenTransferEncoding.tPayload.tls12Cbc!.closeNotify = true
+		assert.throws(
+			() => validateTeeTranscriptContract(
+				hiddenTransferEncoding.bundle,
+				hiddenTransferEncoding.kPayload,
+				hiddenTransferEncoding.tPayload,
+			),
+			/redacts a framing header/,
+		)
+
+		const emptyTransferCoding = makeCbcContract(
+			request,
+			encoder.encode('HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip,\r\n\r\nOK'),
+			99,
+			99,
+		)
+		emptyTransferCoding.tPayload.tls12Cbc!.closeNotify = true
+		assert.throws(
+			() => validateTeeTranscriptContract(
+				emptyTransferCoding.bundle,
+				emptyTransferCoding.kPayload,
+				emptyTransferCoding.tPayload,
+			),
+			/invalid Transfer-Encoding/,
+		)
+	})
+
+	it('requires signed close_notify only for close-delimited CBC responses', () => {
+		const contract = makeCbcContract(
+			encoder.encode('request'),
+			encoder.encode('HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nOK'),
+			99,
+			99,
+		)
+		assert.throws(
+			() => validateTeeTranscriptContract(contract.bundle, contract.kPayload, contract.tPayload),
+			/missing authenticated close_notify/,
+		)
+
+		contract.tPayload.tls12Cbc!.closeNotify = true
+		assert.equal(validateTeeTranscriptContract(contract.bundle, contract.kPayload, contract.tPayload), 'tls12-cbc')
+	})
+
+	it('round-trips the additive CBC close_notify field', () => {
+		const withClose = TLS12CBCTOutput.create({ closeNotify: true })
+		const decoded = TLS12CBCTOutput.decode(TLS12CBCTOutput.encode(withClose).finish())
+		assert.equal(decoded.closeNotify, true)
+
+		const oldEncoding = new Uint8Array()
+		assert.equal(TLS12CBCTOutput.decode(oldEncoding).closeNotify, false)
 	})
 
 	it('rejects legacy ZK TOPRF data for CBC', () => {
@@ -238,6 +385,45 @@ describe('TEE TLS 1.2 CBC contract', () => {
 		)
 	})
 
+	it('keeps the pre-CBC OPRF MPC count behavior unchanged', () => {
+		const makeLegacyOutput = (position: number) => OPRFOutput.create({
+			tlsStart: position,
+			tlsLength: 1,
+			hashOutput: new Uint8Array(32).fill(position + 1),
+		})
+		const count = MAX_TEE_OPRF_MPC_OUTPUTS + 1
+		const kOutputs = Array.from({ length: count }, (_, index) => makeLegacyOutput(index))
+		const tOutputs = kOutputs.map(output => OPRFOutput.create({
+			...output,
+			hashOutput: new Uint8Array(output.hashOutput),
+		}))
+		const kPayload = KOutputPayload.create({ oprfOutputs: kOutputs })
+		const tPayload = TOutputPayload.create({
+			oprfOutputs: tOutputs,
+			consolidatedResponseCiphertext: new Uint8Array(count),
+		})
+
+		assert.equal(verifyOprfMpcOutputs(kPayload, tPayload, logger).length, count)
+	})
+
+	it('reconstructs CBC chunk trailers without treating them as chunk sizes', async() => {
+		const response = encoder.encode(
+			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n' +
+			'2;hidden=VALUE\r\nOK\r\n0\r\nX-Trailer: value\r\n\r\n',
+		)
+		const contract = makeCbcContract(encoder.encode('request'), response, 99, 999)
+		assert.equal(validateTeeTranscriptContract(contract.bundle, contract.kPayload, contract.tPayload), 'tls12-cbc')
+
+		const transcript = await reconstructTlsTranscript(
+			makeBundleData(contract.kPayload, contract.tPayload, 'tls12-cbc'),
+			logger,
+		)
+		const reconstructed = decoder.decode(transcript.reconstructedResponse)
+		assert.ok(reconstructed.endsWith('\r\n\r\nOK'))
+		assert.ok(!reconstructed.includes('hidden=VALUE'))
+		assert.ok(!reconstructed.includes('X-Trailer'))
+	})
+
 	it('rejects OPRF ranges over chunk framing', async() => {
 		const header = 'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n'
 		const response = encoder.encode(`${header}3\r\nabc\r\n5\r\ndefgh\r\n0\r\n\r\n`)
@@ -255,45 +441,6 @@ describe('TEE TLS 1.2 CBC contract', () => {
 		await assert.rejects(
 			reconstructTlsTranscript(makeBundleData(contract.kPayload, contract.tPayload, 'tls12-cbc'), logger, verified),
 			/not wholly contained in HTTP chunk data/,
-		)
-	})
-
-	it('rejects overlapping OPRF sources before reconstruction', () => {
-		assert.throws(
-			() => validateAndCombineOprfResults(
-				[{ position: 4, length: 2, output: new Uint8Array(32) }],
-				[{ position: 4, length: 2, output: new Uint8Array(32), isMPC: true }],
-				logger,
-			),
-			/Overlapping OPRF ranges/,
-		)
-	})
-
-	it('rejects oversized TEE verification bundles before protobuf decoding', async() => {
-		await assert.rejects(
-			verifyTeeBundle(new Uint8Array(MAX_TEE_VERIFICATION_BUNDLE_SIZE + 1), logger),
-			/exceeds the maximum size/,
-		)
-	})
-
-	it('rejects oversized signed bodies before nested protobuf decoding', async() => {
-		const bundle = VerificationBundle.create({
-			teekSigned: SignedMessage.create({
-				bodyType: BodyType.BODY_TYPE_K_OUTPUT,
-				body: new Uint8Array(MAX_TEE_SIGNED_BODY_SIZE + 1),
-				ethAddress: new Uint8Array([1]),
-				signature: new Uint8Array([1]),
-			}),
-			teetSigned: SignedMessage.create({
-				bodyType: BodyType.BODY_TYPE_T_OUTPUT,
-				body: new Uint8Array([1]),
-				ethAddress: new Uint8Array([1]),
-				signature: new Uint8Array([1]),
-			}),
-		})
-		await assert.rejects(
-			verifyTeeBundle(VerificationBundle.encode(bundle).finish(), logger),
-			/signed body exceeds the maximum size/,
 		)
 	})
 
@@ -321,6 +468,103 @@ describe('TEE TLS 1.2 CBC contract', () => {
 		)
 		assert.deepEqual(transcript.revealedRequest, request)
 		assert.deepEqual(transcript.reconstructedResponse, response)
+	})
+
+	it('preserves pre-CBC chunk-boundary OPRF coordinate mapping', async() => {
+		const header = 'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n'
+		const response = encoder.encode(`${header}3\r\nabc\r\n3\r\ndef\r\n0\r\n\r\n`)
+		const keystream = new Uint8Array(response.length)
+		const kPayload = KOutputPayload.create({
+			redactedRequest: encoder.encode('GET /legacy HTTP/1.1\r\n\r\n'),
+			consolidatedResponseKeystream: keystream,
+			certificateInfo: testCertificate(),
+			sessionId: 'legacy-chunk-session',
+		})
+		const tPayload = TOutputPayload.create({
+			consolidatedResponseCiphertext: response,
+			sessionId: 'legacy-chunk-session',
+		})
+		const firstChunkStart = findBytes(response, encoder.encode('abc'))
+		const output = new Uint8Array(32).fill(8)
+
+		const transcript = await reconstructTlsTranscript(
+			makeBundleData(kPayload, tPayload, 'split-aead'),
+			logger,
+			[{ position: firstChunkStart + 3, length: 3, output, isMPC: true }],
+		)
+		assert.ok(decoder.decode(transcript.reconstructedResponse).endsWith(`\r\n\r\nabc${bs58.encode(output)}`))
+	})
+
+	it('accepts an encoded pre-CBC standalone bundle', async() => {
+		const timestampMs = Date.now()
+		const kPayload = KOutputPayload.create({
+			redactedRequest: encoder.encode('GET /legacy HTTP/1.1\r\n\r\n'),
+			consolidatedResponseKeystream: new Uint8Array([1, 2]),
+			certificateInfo: testCertificate(),
+			timestampMs,
+			sessionId: 'pre-cbc-session',
+		})
+		const tPayload = TOutputPayload.create({
+			consolidatedResponseCiphertext: new Uint8Array([3, 4]),
+			timestampMs,
+			sessionId: 'pre-cbc-session',
+		})
+		const teekWallet = Wallet.createRandom()
+		const teetWallet = Wallet.createRandom()
+		const kBody = KOutputPayload.encode(kPayload).finish()
+		const tBody = TOutputPayload.encode(tPayload).finish()
+		const bundle = VerificationBundle.create({
+			teekSigned: SignedMessage.create({
+				bodyType: BodyType.BODY_TYPE_K_OUTPUT,
+				body: kBody,
+				ethAddress: encoder.encode(teekWallet.address),
+				signature: await ETH_SIGNATURE_PROVIDER.sign(kBody, teekWallet.privateKey),
+			}),
+			teetSigned: SignedMessage.create({
+				bodyType: BodyType.BODY_TYPE_T_OUTPUT,
+				body: tBody,
+				ethAddress: encoder.encode(teetWallet.address),
+				signature: await ETH_SIGNATURE_PROVIDER.sign(tBody, teetWallet.privateKey),
+			}),
+		})
+
+		const previousStandalone = process.env.TEE_STANDALONE
+		process.env.TEE_STANDALONE = 'true'
+		try {
+			const verified = await verifyTeeBundle(VerificationBundle.encode(bundle).finish(), logger)
+			assert.equal(verified.protocolMode, 'split-aead')
+			assert.equal(verified.teeSessionId, 'pre-cbc-session')
+		} finally {
+			if(previousStandalone === undefined) {
+				delete process.env.TEE_STANDALONE
+			} else {
+				process.env.TEE_STANDALONE = previousStandalone
+			}
+		}
+	})
+
+	it('decodes and re-encodes pre-CBC protobuf bytes exactly', () => {
+		// Generated with the pre-CBC codec from attestor-core HEAD^.
+		const kWire = new Uint8Array(Buffer.from(
+			'0a03474554120f080110011a0973656e7369746976651a030102032a040802100130c0c4073a066c6567616379',
+			'hex',
+		))
+		const tWire = new Uint8Array(Buffer.from(
+			'0a0304050612010918c0c40722066c6567616379',
+			'hex',
+		))
+		const bundleWire = new Uint8Array(Buffer.from(
+			'0a370801122d0a03474554120f080110011a0973656e7369746976651a030102032a040802100130c0c4073a066c65676163791a0108220107121e080212140a0304050612010918c0c40722066c65676163791a010b22010a',
+			'hex',
+		))
+
+		const kPayload = KOutputPayload.decode(kWire)
+		const tPayload = TOutputPayload.decode(tWire)
+		assert.equal(kPayload.tls12Cbc, undefined)
+		assert.equal(tPayload.tls12Cbc, undefined)
+		assert.deepEqual(KOutputPayload.encode(kPayload).finish(), kWire)
+		assert.deepEqual(TOutputPayload.encode(tPayload).finish(), tWire)
+		assert.deepEqual(VerificationBundle.encode(VerificationBundle.decode(bundleWire)).finish(), bundleWire)
 	})
 })
 

--- a/src/tests/tee-cbc-contract.test.ts
+++ b/src/tests/tee-cbc-contract.test.ts
@@ -1,0 +1,416 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import bs58 from 'bs58'
+import { Wallet } from 'ethers'
+
+import {
+	BodyType,
+	CertificateInfo,
+	KOutputPayload,
+	OPRFOutput,
+	OPRFVerificationData,
+	SignedMessage,
+	TLS12CBCKOutput,
+	TLS12CBCRecordMode,
+	TLS12CBCSessionBinding,
+	TLS12CBCTOutput,
+	TOutputPayload,
+	VerificationBundle,
+} from '#src/proto/tee-bundle.ts'
+import { validateAndCombineOprfResults } from '#src/server/handlers/claimTeeBundle.ts'
+import { validateTeeTranscriptContract } from '#src/server/utils/tee-cbc-contract.ts'
+import { MAX_TEE_OPRF_MPC_OUTPUTS, verifyOprfMpcOutputs } from '#src/server/utils/tee-oprf-mpc-verification.ts'
+import { reconstructTlsTranscript } from '#src/server/utils/tee-transcript-reconstruction.ts'
+import {
+	MAX_TEE_SIGNED_BODY_SIZE,
+	MAX_TEE_VERIFICATION_BUNDLE_SIZE,
+	type TeeBundleData,
+	verifyTeeBundle,
+} from '#src/server/utils/tee-verification.ts'
+import { logger } from '#src/utils/logger.ts'
+import { ETH_SIGNATURE_PROVIDER } from '#src/utils/signatures/eth.ts'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+describe('TEE TLS 1.2 CBC contract', () => {
+	it('accepts a complete CBC contract and reconstructs signed redactions', async() => {
+		const request = encoder.encode('GET / HTTP/1.1\r\nHost: example.com\r\nAuthorization: SECRET\r\n\r\n')
+		const requestSecret = findBytes(request, encoder.encode('SECRET'))
+		const response = encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nSECRET')
+		const responseSecret = findBytes(response, encoder.encode('SECRET'))
+		const { bundle, kPayload, tPayload } = makeCbcContract(request, response, requestSecret, responseSecret)
+
+		assert.equal(validateTeeTranscriptContract(bundle, kPayload, tPayload), 'tls12-cbc')
+		const transcript = await reconstructTlsTranscript(
+			makeBundleData(kPayload, tPayload, 'tls12-cbc'),
+			logger,
+		)
+		assert.equal(
+			decoder.decode(transcript.revealedRequest),
+			'GET / HTTP/1.1\r\nHost: example.com\r\nAuthorization: ******\r\n\r\n',
+		)
+		assert.equal(
+			decoder.decode(transcript.reconstructedResponse),
+			'HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\n******',
+		)
+	})
+
+	it('accepts an encoded and signed standalone CBC bundle', async() => {
+		const contract = makeCbcContract(
+			encoder.encode('GET /signed HTTP/1.1\r\n\r\n'),
+			encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK'),
+			0,
+			0,
+		)
+		const teekWallet = Wallet.createRandom()
+		const teetWallet = Wallet.createRandom()
+		const kBody = KOutputPayload.encode(contract.kPayload).finish()
+		const tBody = TOutputPayload.encode(contract.tPayload).finish()
+		contract.bundle.teekSigned = SignedMessage.create({
+			bodyType: BodyType.BODY_TYPE_K_OUTPUT,
+			body: kBody,
+			ethAddress: encoder.encode(teekWallet.address),
+			signature: await ETH_SIGNATURE_PROVIDER.sign(kBody, teekWallet.privateKey),
+		})
+		contract.bundle.teetSigned = SignedMessage.create({
+			bodyType: BodyType.BODY_TYPE_T_OUTPUT,
+			body: tBody,
+			ethAddress: encoder.encode(teetWallet.address),
+			signature: await ETH_SIGNATURE_PROVIDER.sign(tBody, teetWallet.privateKey),
+		})
+
+		const previousStandalone = process.env.TEE_STANDALONE
+		process.env.TEE_STANDALONE = 'true'
+		try {
+			const verified = await verifyTeeBundle(VerificationBundle.encode(contract.bundle).finish(), logger)
+			assert.equal(verified.protocolMode, 'tls12-cbc')
+			assert.equal(verified.teeSessionId, 'cbc-session')
+		} finally {
+			if(previousStandalone === undefined) {
+				delete process.env.TEE_STANDALONE
+			} else {
+				process.env.TEE_STANDALONE = previousStandalone
+			}
+		}
+	})
+
+	it('rejects a one-sided or mixed CBC contract', () => {
+		const { bundle, kPayload, tPayload } = makeCbcContract(
+			encoder.encode('request'),
+			encoder.encode('response'),
+			0,
+			0,
+		)
+		tPayload.tls12Cbc = undefined
+		assert.throws(
+			() => validateTeeTranscriptContract(bundle, kPayload, tPayload),
+			/CBC contract must be present in both TEE payloads/,
+		)
+
+		const mixed = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 0, 0)
+		mixed.kPayload.consolidatedResponseKeystream = new Uint8Array([1])
+		assert.throws(
+			() => validateTeeTranscriptContract(mixed.bundle, mixed.kPayload, mixed.tPayload),
+			/mixes legacy split-AEAD fields/,
+		)
+	})
+
+	it('rejects binding, digest, range, and record-length tampering', () => {
+		const bindingMismatch = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 0, 0)
+		bindingMismatch.tPayload.tls12Cbc!.binding!.sessionBinding[0] ^= 1
+		assert.throws(
+			() => validateTeeTranscriptContract(bindingMismatch.bundle, bindingMismatch.kPayload, bindingMismatch.tPayload),
+			/session binding mismatch/,
+		)
+
+		const badDigest = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 0, 0)
+		badDigest.kPayload.tls12Cbc!.requestRecordsSha256 = new Uint8Array(31)
+		assert.throws(
+			() => validateTeeTranscriptContract(badDigest.bundle, badDigest.kPayload, badDigest.tPayload),
+			/request record digest must be 32 bytes/,
+		)
+
+		const badRange = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 0, 0)
+		badRange.tPayload.tls12Cbc!.responseRedactionRanges = [{ start: 7, length: 2 }]
+		assert.throws(
+			() => validateTeeTranscriptContract(badRange.bundle, badRange.kPayload, badRange.tPayload),
+			/response redaction range 0 is out of bounds/,
+		)
+
+		const badLengths = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 0, 0)
+		badLengths.tPayload.tls12Cbc!.plaintextRecordLengths = [7]
+		assert.throws(
+			() => validateTeeTranscriptContract(badLengths.bundle, badLengths.kPayload, badLengths.tPayload),
+			/record lengths do not match/,
+		)
+	})
+
+	it('accepts all twelve supported AES-CBC cipher suites', () => {
+		const suites = [
+			0xc009, 0xc013, 0xc00a, 0xc014, 0xc023, 0xc027,
+			0xc024, 0xc028, 0x002f, 0x0035, 0x003c, 0x003d,
+		]
+		for(const cipherSuite of suites) {
+			const contract = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 99, 99)
+			contract.kPayload.tls12Cbc!.binding!.cipherSuite = cipherSuite
+			contract.tPayload.tls12Cbc!.binding!.cipherSuite = cipherSuite
+			assert.equal(
+				validateTeeTranscriptContract(contract.bundle, contract.kPayload, contract.tPayload),
+				'tls12-cbc',
+			)
+		}
+	})
+
+	it('rejects legacy ZK TOPRF data for CBC', () => {
+		const contract = makeCbcContract(encoder.encode('request'), encoder.encode('response'), 0, 0)
+		contract.bundle.oprfVerifications = [OPRFVerificationData.create({
+			streamPos: 0,
+			streamLength: 1,
+			publicSignalsJson: new Uint8Array([1]),
+		})]
+		assert.throws(
+			() => validateTeeTranscriptContract(contract.bundle, contract.kPayload, contract.tPayload),
+			/does not support legacy ZK TOPRF/,
+		)
+	})
+
+	it('uses matching CBC MPC OPRF outputs and rejects out-of-bounds positions', async() => {
+		const request = encoder.encode('GET / HTTP/1.1\r\n\r\n')
+		const response = encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nSECRET')
+		const secretStart = findBytes(response, encoder.encode('SECRET'))
+		const contract = makeCbcContract(request, response, 0, secretStart)
+		const hashOutput = new Uint8Array(32).fill(9)
+		const output = OPRFOutput.create({ tlsStart: secretStart, tlsLength: 6, hashOutput })
+		contract.kPayload.oprfOutputs = [output]
+		contract.tPayload.oprfOutputs = [OPRFOutput.create({
+			...output,
+			hashOutput: new Uint8Array(hashOutput),
+		})]
+
+		const verified = verifyOprfMpcOutputs(contract.kPayload, contract.tPayload, logger)
+		const transcript = await reconstructTlsTranscript(
+			makeBundleData(contract.kPayload, contract.tPayload, 'tls12-cbc'),
+			logger,
+			verified,
+		)
+		assert.equal(
+			decoder.decode(transcript.reconstructedResponse),
+			`HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\n${bs58.encode(hashOutput)}`,
+		)
+
+		contract.kPayload.oprfOutputs[0].tlsStart = response.length
+		contract.tPayload.oprfOutputs[0].tlsStart = response.length
+		assert.throws(
+			() => verifyOprfMpcOutputs(contract.kPayload, contract.tPayload, logger),
+			/exceeds authenticated response length/,
+		)
+	})
+
+	it('caps and de-duplicates MPC OPRF ranges', () => {
+		const response = new Uint8Array(128)
+		const contract = makeCbcContract(encoder.encode('request'), response, 99, 999)
+		const makeOutput = (position: number) => OPRFOutput.create({
+			tlsStart: position,
+			tlsLength: 1,
+			hashOutput: new Uint8Array(32).fill(position + 1),
+		})
+		contract.kPayload.oprfOutputs = Array.from({ length: MAX_TEE_OPRF_MPC_OUTPUTS }, (_, i) => makeOutput(i))
+		contract.tPayload.oprfOutputs = contract.kPayload.oprfOutputs.map(output => OPRFOutput.create({
+			...output,
+			hashOutput: new Uint8Array(output.hashOutput),
+		}))
+		assert.equal(verifyOprfMpcOutputs(contract.kPayload, contract.tPayload, logger).length, MAX_TEE_OPRF_MPC_OUTPUTS)
+
+		contract.kPayload.oprfOutputs.push(makeOutput(MAX_TEE_OPRF_MPC_OUTPUTS))
+		contract.tPayload.oprfOutputs.push(makeOutput(MAX_TEE_OPRF_MPC_OUTPUTS))
+		assert.throws(
+			() => verifyOprfMpcOutputs(contract.kPayload, contract.tPayload, logger),
+			/Too many OPRF MPC outputs/,
+		)
+
+		contract.kPayload.oprfOutputs = [makeOutput(3), makeOutput(3)]
+		contract.tPayload.oprfOutputs = [makeOutput(3), makeOutput(3)]
+		assert.throws(
+			() => verifyOprfMpcOutputs(contract.kPayload, contract.tPayload, logger),
+			/OPRF MPC ranges overlap/,
+		)
+	})
+
+	it('rejects OPRF ranges over chunk framing', async() => {
+		const header = 'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n'
+		const response = encoder.encode(`${header}3\r\nabc\r\n5\r\ndefgh\r\n0\r\n\r\n`)
+		const contract = makeCbcContract(encoder.encode('request'), response, 99, 999)
+		const framingPosition = encoder.encode(header).length
+		const output = OPRFOutput.create({
+			tlsStart: framingPosition,
+			tlsLength: 1,
+			hashOutput: new Uint8Array(32).fill(7),
+		})
+		contract.kPayload.oprfOutputs = [output]
+		contract.tPayload.oprfOutputs = [OPRFOutput.create({ ...output, hashOutput: new Uint8Array(output.hashOutput) })]
+		const verified = verifyOprfMpcOutputs(contract.kPayload, contract.tPayload, logger)
+
+		await assert.rejects(
+			reconstructTlsTranscript(makeBundleData(contract.kPayload, contract.tPayload, 'tls12-cbc'), logger, verified),
+			/not wholly contained in HTTP chunk data/,
+		)
+	})
+
+	it('rejects overlapping OPRF sources before reconstruction', () => {
+		assert.throws(
+			() => validateAndCombineOprfResults(
+				[{ position: 4, length: 2, output: new Uint8Array(32) }],
+				[{ position: 4, length: 2, output: new Uint8Array(32), isMPC: true }],
+				logger,
+			),
+			/Overlapping OPRF ranges/,
+		)
+	})
+
+	it('rejects oversized TEE verification bundles before protobuf decoding', async() => {
+		await assert.rejects(
+			verifyTeeBundle(new Uint8Array(MAX_TEE_VERIFICATION_BUNDLE_SIZE + 1), logger),
+			/exceeds the maximum size/,
+		)
+	})
+
+	it('rejects oversized signed bodies before nested protobuf decoding', async() => {
+		const bundle = VerificationBundle.create({
+			teekSigned: SignedMessage.create({
+				bodyType: BodyType.BODY_TYPE_K_OUTPUT,
+				body: new Uint8Array(MAX_TEE_SIGNED_BODY_SIZE + 1),
+				ethAddress: new Uint8Array([1]),
+				signature: new Uint8Array([1]),
+			}),
+			teetSigned: SignedMessage.create({
+				bodyType: BodyType.BODY_TYPE_T_OUTPUT,
+				body: new Uint8Array([1]),
+				ethAddress: new Uint8Array([1]),
+				signature: new Uint8Array([1]),
+			}),
+		})
+		await assert.rejects(
+			verifyTeeBundle(VerificationBundle.encode(bundle).finish(), logger),
+			/signed body exceeds the maximum size/,
+		)
+	})
+
+	it('preserves the legacy split-AEAD reconstruction path', async() => {
+		const request = encoder.encode('GET /legacy HTTP/1.1\r\n\r\n')
+		const response = encoder.encode('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK')
+		const keystream = new Uint8Array(response.length).fill(0x55)
+		const ciphertext = response.map((value, index) => value ^ keystream[index])
+		const kPayload = KOutputPayload.create({
+			redactedRequest: request,
+			consolidatedResponseKeystream: keystream,
+			certificateInfo: testCertificate(),
+			sessionId: 'legacy-session',
+		})
+		const tPayload = TOutputPayload.create({
+			consolidatedResponseCiphertext: ciphertext,
+			sessionId: 'legacy-session',
+		})
+		const bundle = VerificationBundle.create({})
+
+		assert.equal(validateTeeTranscriptContract(bundle, kPayload, tPayload), 'split-aead')
+		const transcript = await reconstructTlsTranscript(
+			makeBundleData(kPayload, tPayload, 'split-aead'),
+			logger,
+		)
+		assert.deepEqual(transcript.revealedRequest, request)
+		assert.deepEqual(transcript.reconstructedResponse, response)
+	})
+})
+
+function makeCbcContract(
+	request: Uint8Array,
+	response: Uint8Array,
+	requestSecret: number,
+	responseSecret: number,
+) {
+	const binding = TLS12CBCSessionBinding.create({
+		contractVersion: 1,
+		cipherSuite: 0xc013,
+		recordMode: TLS12CBCRecordMode.TLS12_CBC_RECORD_MODE_MAC_THEN_ENCRYPT,
+		extendedMasterSecret: true,
+		sessionBinding: new Uint8Array(32).fill(7),
+	})
+	const requestRanges = request.length >= requestSecret + 6
+		? [{ start: requestSecret, length: 6, type: 'sensitive' }]
+		: []
+	const responseRanges = response.length >= responseSecret + 6
+		? [{ start: responseSecret, length: 6 }]
+		: []
+	const kPayload = KOutputPayload.create({
+		certificateInfo: testCertificate(),
+		timestampMs: Date.now(),
+		sessionId: 'cbc-session',
+		tls12Cbc: TLS12CBCKOutput.create({
+			binding,
+			authenticatedRedactedRequest: request,
+			requestRecordsSha256: new Uint8Array(32).fill(1),
+			requestRedactionRanges: requestRanges,
+		}),
+	})
+	const tPayload = TOutputPayload.create({
+		timestampMs: Date.now(),
+		sessionId: 'cbc-session',
+		tls12Cbc: TLS12CBCTOutput.create({
+			binding: TLS12CBCSessionBinding.create({
+				...binding,
+				sessionBinding: new Uint8Array(binding.sessionBinding),
+			}),
+			authenticatedRedactedResponse: response,
+			responseRecordsSha256: new Uint8Array(32).fill(2),
+			responseRedactionRanges: responseRanges,
+			plaintextRecordLengths: [response.length],
+		}),
+	})
+	return { bundle: VerificationBundle.create({}), kPayload, tPayload }
+}
+
+function makeBundleData(
+	kOutputPayload: KOutputPayload,
+	tOutputPayload: TOutputPayload,
+	protocolMode: TeeBundleData['protocolMode'],
+): TeeBundleData {
+	const emptyK = SignedMessage.create({ bodyType: BodyType.BODY_TYPE_K_OUTPUT })
+	const emptyT = SignedMessage.create({ bodyType: BodyType.BODY_TYPE_T_OUTPUT })
+	return {
+		teekSigned: emptyK,
+		teetSigned: emptyT,
+		kOutputPayload,
+		tOutputPayload,
+		teekPcr0: 'test-k',
+		teetPcr0: 'test-t',
+		teeSessionId: kOutputPayload.sessionId,
+		protocolMode,
+	}
+}
+
+function testCertificate() {
+	return CertificateInfo.create({
+		commonName: 'example.com',
+		dnsNames: ['example.com'],
+		notBeforeUnix: 1,
+		notAfterUnix: 4_000_000_000,
+	})
+}
+
+function findBytes(haystack: Uint8Array, needle: Uint8Array): number {
+	for(let start = 0; start <= haystack.length - needle.length; start++) {
+		let match = true
+		for(let offset = 0; offset < needle.length; offset++) {
+			if(haystack[start + offset] !== needle[offset]) {
+				match = false
+				break
+			}
+		}
+		if(match) {
+			return start
+		}
+	}
+	throw new Error('test fixture substring not found')
+}


### PR DESCRIPTION
## Summary

- Add a versioned signed TLS 1.2 CBC contract shared by TEE_K and TEE_T.
- Verify all 12 AES-CBC suites in both MAC-then-encrypt and encrypt-then-MAC modes.
- Reconstruct authenticated CBC plaintext while rejecting mixed split-AEAD/CBC bundles.
- Enforce OPRF count, overlap, bounds, HTTP chunk-data containment, and bundle/body size limits.

## Trust boundary

- TEE_K can see the request for TLS 1.2 CBC sessions.
- TEE_T authenticates and can see the response.
- CBC does not use the legacy ZK symmetric-record proof path.

## Verification

- npm run run:test-files -- src/tests/tee-cbc-contract.test.ts: 13 passed.
- npx tsc -p tsconfig.build.json --noEmit: passed.
- npm run lint: passed.
- Fresh protoc output exactly matches the committed TypeScript binding.
- Manual standalone E2E against example.com negotiated TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA and completed claim issuance plus MPC OPRF.

## Existing test-suite issues

The full suite reported 163 passed, 2 skipped, and 3 failures in unchanged network/RPC tests. The DNS timeout and WebSocket close-timing failures reproduce in isolation. The RPC tunnel file passes 6/6 in isolation after its combined-run alert-wording failure. The repository-wide test-inclusive TypeScript check also reports existing errors only in unchanged AVS, signature, and ZK tests; the production build configuration passes.