### PR TITLE
Compliance: add .github/asset-classification.yml (Restricted / Critical)

### DIFF
--- a/.github/asset-classification.yml
+++ b/.github/asset-classification.yml
@@ -1,0 +1,13 @@
+# Asset Management Policy — repository asset record
+# Draft generated from the Repository Policy Reflection register (2026-08-26).
+# Owners MUST fill the TBD fields and approve before this record counts as implemented.
+policy_version: TBD
+classification: Restricted
+criticality: Critical
+business_owner: TBD
+technical_owner: TBD
+reviewed_on: 2026-08-26
+review_status: draft-pending-owner-approval
+exception_reference: none
+rationale: >-
+  Add repository classification metadata; require protocol/security-owner attestation.


### PR DESCRIPTION
Adds a machine-readable asset record per the Asset Management Policy reflection register (2026-08-26).

Classification: **Restricted** · Criticality: **Critical**

Add repository classification metadata; require protocol/security-owner attestation.

Owner fields are TBD on purpose — please set business_owner, technical_owner and policy_version, then approve. This record is not 'implemented' until a named owner signs off. Does not attest branch protection, secret history, or deployment permissions.