### PR TITLE
[CHORE] Update zk-symmetric-crypto to 5.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@peculiar/webcrypto": "^1.5.0",
         "@peculiar/x509": "^1.14.3",
         "@reclaimprotocol/tls": "^0.1.3",
-        "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
+        "@reclaimprotocol/zk-symmetric-crypto": "^5.1.5",
         "ajv": "^8.18.0",
         "bs58": "^6.0.0",
         "canonicalize": "^2.1.0",
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/@reclaimprotocol/zk-symmetric-crypto": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@reclaimprotocol/zk-symmetric-crypto/-/zk-symmetric-crypto-5.1.3.tgz",
-      "integrity": "sha512-ABP0fO13Vp2ZPx+34RpEwedhk1EtDTlHTet52KggDDI4uJwb6Y6rDg2EdTN/eTrXwVtN5s3mMk21u2eJE1SPsg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@reclaimprotocol/zk-symmetric-crypto/-/zk-symmetric-crypto-5.1.5.tgz",
+      "integrity": "sha512-uoD9mUA0MogVJ/f1z7IbJ1j47sr6u87ekepmmaCuXpSg0IqHh/Hp0ZV8hCgHpct2lT+6A2+V4ys+lJtjxcXccA==",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "js-base64": "^3.7.7"
@@ -9204,9 +9204,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.3.tgz",
+      "integrity": "sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-sha3": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^1.14.3",
     "@reclaimprotocol/tls": "^0.1.3",
-    "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
+    "@reclaimprotocol/zk-symmetric-crypto": "^5.1.5",
     "ajv": "^8.18.0",
     "bs58": "^6.0.0",
     "canonicalize": "^2.1.0",


### PR DESCRIPTION
### Description

Updates `@reclaimprotocol/zk-symmetric-crypto` from `^5.1.3` to `^5.1.5`.

Version 5.1.5 is built from `bd1c5c6baa78c6d07be4bf84b7f2e9f0fa16657f`. It updates the native gnark libraries to gnark 0.16.3 while retaining the frozen v0.14 circuit artifacts for client compatibility.

### Testing

- `npm run download:zk-files` downloaded the exact `bd1c5c6` archive
- `npm run build`
- `npm run lint`
- Gnark and TOPRF proof tests passed with the frozen circuit artifacts
- Current TEE client end-to-end flow was validated against the updated Attestor
- Full local suite: 169 passed, 3 failed on network/timing assertions. Isolated reruns passed the TLS alert case; the DNS timeout and socket-close timing assertions remained reproducible locally.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:

- [ ] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [ ] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [ ] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:

The zk package publish completed successfully. Its workflow reported failure afterward because the publish script attempted to push its generated version commit directly to protected `main`.
