### PR TITLE
[FIX] Restore browser build with zk 5.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@peculiar/webcrypto": "^1.5.0",
         "@peculiar/x509": "^1.14.3",
         "@reclaimprotocol/tls": "^0.1.3",
-        "@reclaimprotocol/zk-symmetric-crypto": "^5.1.5",
+        "@reclaimprotocol/zk-symmetric-crypto": "^5.1.6",
         "ajv": "^8.18.0",
         "bs58": "^6.0.0",
         "canonicalize": "^2.1.0",
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/@reclaimprotocol/zk-symmetric-crypto": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@reclaimprotocol/zk-symmetric-crypto/-/zk-symmetric-crypto-5.1.5.tgz",
-      "integrity": "sha512-uoD9mUA0MogVJ/f1z7IbJ1j47sr6u87ekepmmaCuXpSg0IqHh/Hp0ZV8hCgHpct2lT+6A2+V4ys+lJtjxcXccA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@reclaimprotocol/zk-symmetric-crypto/-/zk-symmetric-crypto-5.1.6.tgz",
+      "integrity": "sha512-7D0Dlp4LYGj/ODB1gUMugsuGn80w7Ac4GthpzNqKoHKotTsMtlAPbNrUSU3hdkqNGxa5Jz8LXgVP5RhdHeADZA==",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
       "dependencies": {
         "js-base64": "^3.7.7"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^1.14.3",
     "@reclaimprotocol/tls": "^0.1.3",
-    "@reclaimprotocol/zk-symmetric-crypto": "^5.1.5",
+    "@reclaimprotocol/zk-symmetric-crypto": "^5.1.6",
     "ajv": "^8.18.0",
     "bs58": "^6.0.0",
     "canonicalize": "^2.1.0",


### PR DESCRIPTION
### Description

Updates `@reclaimprotocol/zk-symmetric-crypto` from `^5.1.5` to `^5.1.6`.

Version 5.1.6 removes the Node-only `url` import from the universal file-fetch entrypoint, restoring Attestor's browser bundle while retaining the gnark 0.16.3 binaries and frozen v0.14 circuit artifacts.

### Testing

- Confirmed npm `gitHead` is `394f777fa404ef184652b6efc5aa60884dd55c7e`
- `npm run download:zk-files` downloaded the exact `394f777` archive
- `npm run build`
- `npm run build:browser`
- `npm run lint`
- Focused ZK/TOPRF suite: 16/16 passed

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist:

- [ ] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [ ] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [ ] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:

Fixes the browser-build failure in https://github.com/reclaimprotocol/attestor-core/actions/runs/33191088464/job/98916424812.
